### PR TITLE
Add `settings=profile` to jcmd JFR.start example

### DIFF
--- a/docs/troubleshooting/docker-jcmd.rst
+++ b/docs/troubleshooting/docker-jcmd.rst
@@ -258,7 +258,7 @@ Example
 Java Flight Recording
 ---------------------
 
-:Command: ``jcmd <PID> JFR.start name=<NAME> duration=<DURATION> filename=<PATH>``
+:Command: ``jcmd <PID> JFR.start name=<NAME> duration=<DURATION> filename=<PATH> settings=profile``
 
 Example
 .......


### PR DESCRIPTION
It will add a bit of overhead to use `settings=profile` but the
recording will be much more helpful in tracking down issues.