### PR TITLE
RPM: Use correct repo definition for CrateDB >= 4.2.0

### DIFF
--- a/docs/deployment/linux/red-hat.rst
+++ b/docs/deployment/linux/red-hat.rst
@@ -34,6 +34,12 @@ For Red Hat Linux 7, run:
 
 .. code-block:: sh
 
+   sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/7/x86_64/crate-release-7.0-1.x86_64.rpm
+
+For CrateDB versions < 4.2.0, run:
+
+.. code-block:: sh
+
    sh$ sudo rpm -Uvh https://cdn.crate.io/downloads/yum/7/noarch/crate-release-7.0-1.noarch.rpm
 
 The above commands will create the ``/etc/yum.repos.d/crate.repo``


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Starting with 4.2.0 we have to build platform-specific
rmp packages. That is the result of binding the platform-specific
JDK with CrateDB.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
