### PR TITLE
Update MongoDB migration guide

### DIFF
--- a/docs/best-practices/migrating-from-mongodb.rst
+++ b/docs/best-practices/migrating-from-mongodb.rst
@@ -13,35 +13,19 @@ Migrating from MongoDB
 Exporting data from MongoDB
 ===========================
 
-MongoDB ships with a command-line tool called mongoexport_. This tool can be
-used to export data in the ``MongoDB Extended JSON`` file format.
+When exporting data from a MongoDB collection, it is exported in the `MongoDB
+Extended JSON`_ file format, which includes additional type information. This
+additional information makes the format unsuitable for importing into a CrateDB
+table. To help with this problem, we have created a `MongoDB migration tool`_
+that can export a MongoDB collection while converting it into a CrateDB friendly
+format.
 
-The Extended JSON format is a custom format from MongoDB that includes type
-information.
-
-In order to export the data invoke the mongoexport tool:
-
-.. code-block:: sh
-
-    mongoexport --db <dbname> --collection <data> --out out.json
-
-To import the data into CrateDB the additional type information must be
-stripped away. In order to do so download the conversion script from the
-`crate-utils repo on github`_:
+First, download & install the tool according to the instructions on the repo.
+You can then export a collection into a JSON file, as follows:
 
 .. code-block:: sh
 
-    curl https://raw.githubusercontent.com/crate/crate-utils/master/migrations/mongodb/convert_json.py -o convert_json.py
-
-Once the script is downloaded convert the data:
-
-.. code-block:: sh
-
-    mongoexport --db <dbname> --collection <data> | python convert_json.py > out.json
-
-.. SEEALSO::
-
- - `MongoDB Manual - Extended JSON <http://docs.mongodb.org/manual/reference/mongodb-extended-json/>`_
+    $ migr8 export --host <mongodb hostname> --port <mongodb port> --database <dbname> --collection <data> > data.json
 
 
 Importing data into CrateDB
@@ -52,10 +36,10 @@ created.
 
 A basic CREATE TABLE statement looks as follows::
 
-    cr> create table mytable (
-    ...     name string,
-    ...     obj object (dynamic)
-    ... ) clustered into 5 shards with (number_of_replicas = 0);
+    cr> CREATE TABLE mytable (
+    ...     name TEXT,
+    ...     obj OBJECT (DYNAMIC)
+    ... ) CLUSTERED INTO 5 SHARDS WITH (number_of_replicas = 0);
     CREATE OK, 1 row affected (... sec)
 
 In CrateDB each field is indexed by default. It is not necessary to create
@@ -64,37 +48,44 @@ any additional indices.
 However, if some fields are never used for filtering, indexing can be turned
 off::
 
-    cr> create table mytable2 (
-    ...     name string,
-    ...     obj object (dynamic),
-    ...     dummy string INDEX OFF
-    ... ) clustered into 5 shards with (number_of_replicas = 0);
+    cr> CREATE TABLE mytable2 (
+    ...     name TEXT,
+    ...     obj OBJECT (DYNAMIC),
+    ...     dummy TEXT INDEX OFF
+    ... ) CLUSTERED INTO 5 SHARDS WITH (number_of_replicas = 0);
     CREATE OK, 1 row affected (... sec)
 
 For fields that contain text consider using a full-text analyzer. This will
 enable great full-text search capabilities. See `Indices and Fulltext Search`_
 for more information.
 
-CrateDB is able to dynamically extend the schema, so it is not necessary to
-define all columns up front.
+CrateDB is able to create dynamically defined table schemas, which can be
+extended as data is inserted, so it is not necessary to define all the columns
+up front::
+
+    cr> CREATE TABLE mytable3 (
+    ...     name TEXT,
+    ...     obj OBJECT (DYNAMIC),
+    ...     dumm TEXT index off
+    ... ) CLUSTERED INTO 5 SHARDS WITH (number_of_replicas = 0, column_policy = 'dynamic')
 
 Given the table above, it is possible to insert new columns at the top level of
 the table and insert arbitrary objects into the **obj** column::
 
-    cr> insert into mytable2 (name, obj, newcol, dummy) values
+    cr> INSERT INTO mytable3 (name, obj, newcol, dummy) VALUES
     ... ('Trillian', {gender = 'female'}, 2804, 'dummy');
     INSERT OK, 1 row affected (... sec)
 
-    cr> refresh table mytable2;
+    cr> REFRESH TABLE mytable3;
     REFRESH OK, 1 row affected (... sec)
 
 .. Hidden: wait for schema update so that newcol is available
 
-    cr> _wait_for_schema_update('doc', 'mytable2', 'newcol')
+    cr> _wait_for_schema_update('doc', 'mytable3', 'newcol')
 
 ::
 
-    cr> select * from mytable2;
+    cr> SELECT * FROM mytable3;
     +-------+----------+--------+----------------------+
     | dummy | name     | newcol | obj                  |
     +-------+----------+--------+----------------------+
@@ -106,10 +97,34 @@ However, this has some limitations. For example timestamps in long format won't
 be recognised as timestamps. Due to this limitation it is recommended to
 specify fields up front.
 
+In these cases, the `MongoDB migration tool`_ can be used to autogenerate
+a schema to fit your collection. For example, to create the above schema without
+resorting to using a dynamic table definition:
+
+.. code-block:: sh
+
+    $ migr8 extract --host <mongodb host> --port <mongodb port> --database <dbname> --collection <data> --scan full --out schema.json
+    $ migr8 translate --infile schema.json
+
+    MongoDB -> CrateDB Exporter :: Schema Extractor
+
+    Collection 'mytable':
+    CREATE TABLE IF NOT EXISTS "doc"."mytable" (
+        "name" TEXT,
+        "obj" OBJECT (DYNAMIC) AS (
+            "gender" TEXT
+        ),
+        "newcol" INTEGER,
+        "dummy" TEXT
+    );
+
+This can be useful for collections with complex or heavily-nested schemas.
+
 .. SEEALSO::
 
  - `Data Definition`_
  - `CREATE TABLE`_
+
 
 After the table has been created the file can be imported using
 `COPY FROM`_.
@@ -117,9 +132,9 @@ After the table has been created the file can be imported using
 There is an entire section dedicated on how to do a data import efficiently.
 Continue reading there: :ref:`efficient_data_import`.
 
-.. _mongoexport: http://docs.mongodb.org/manual/reference/program/mongoexport/
-.. _crate-utils repo on github: https://github.com/crate/crate-utils/tree/master/migrations/mongodb
 .. _Indices and Fulltext Search: https://crate.io/docs/crate/reference/sql/ddl/indices_full_search.html
 .. _Data Definition: https://crate.io/docs/crate/reference/sql/ddl/index.html
 .. _CREATE TABLE: https://crate.io/docs/crate/reference/sql/reference/create_table.html
 .. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
+.. _MongoDB Extended JSON: http://docs.mongodb.org/manual/reference/mongodb-extended-json/
+.. _MongoDB migration tool: https://github.com/crate/mongodb-cratedb-migration-tool


### PR DESCRIPTION
This adds reference to our MongoDB migration tool to the migration
guide. It also explicitly clarifies that for a table to dynamically
update its schema, it has to be created with the dynamic column policy
(this used to be dynamic by default, but is now strict by default).