### PR TITLE
Replace command with args in Kubernetes guide

### DIFF
--- a/docs/deployment/containers/kubernetes.rst
+++ b/docs/deployment/containers/kubernetes.rst
@@ -246,8 +246,7 @@ CrateDB 3.0.5 cluster:
             # the name of the pod.
             # We are using the SRV records provided by Kubernetes to discover
             # nodes within the cluster.
-            command:
-              - /docker-entrypoint.sh
+            args:
               - -Cnode.name=${POD_NAME}
               - -Ccluster.name=${CLUSTER_NAME}
               - -Ccluster.initial_master_nodes=crate-0,crate-1,crate-2


### PR DESCRIPTION
This way, you don't have to explicitly call the docker startup script.
