### PR TITLE
Upgrade docs theme to 0.11.0b1 to test cache index

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme==0.11.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # don't pin crate version numbers so the latest will always be pulled when you
 # set up your environment from scratch
 
-crate-docs-theme>=0.8.0
+crate-docs-theme==0.11.0b1
 
 # packages for local dev
 


### PR DESCRIPTION
@msbt Ive released your pull request against crate-docs-theme as 0.11.0b1 (https://pypi.org/project/crate-docs-theme/0.11.0b1/) - this PR sets this as a requirement for the howto guides. When merged to master, this'll deploy your changes to the crate-howtos, and we can see how it performs live.