### PR TITLE
Remove deb-src entry from crate-CHANNEL.list

### DIFF
--- a/docs/deployment/linux/ubuntu.rst
+++ b/docs/deployment/linux/ubuntu.rst
@@ -76,7 +76,6 @@ Then, edit it, and add the following:
 .. code-block:: text
 
    deb https://cdn.crate.io/downloads/deb/CHANNEL/ CODENAME main
-   deb-src https://cdn.crate.io/downloads/deb/CHANNEL/ CODENAME main
 
 Here, replace ``CHANNEL`` as above, and then, additionally, replace
 ``CODENAME`` with the codename of your distribution, which can be round by


### PR DESCRIPTION
We don't publish source packages.

Closes https://github.com/crate/crate/issues/10625