### PR TITLE
Trim headlines within navigation/toctree at "Integrations" section

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -10,22 +10,22 @@ tools.
 .. toctree::
    :maxdepth: 1
 
-   kafka-connect
-   streamsets
+   Apache Kafka <kafka-connect>
+   StreamSets <streamsets>
 
 .. rubric:: Enrichment
 
 .. toctree::
     :maxdepth: 1
 
-    azure-functions
+    Azure IoT Hub and Functions <azure-functions>
 
 .. rubric:: Data Analysis, Visualization, and Machine Learning
 
 .. toctree::
     :maxdepth: 1
 
-    r
-    powerbi-desktop
-    powerbi-gateway
-    ml-dist
+    R <r>
+    PowerBI Desktop <powerbi-desktop>
+    PowerBI Real Time Reports <powerbi-gateway>
+    TensorFlow <ml-dist>


### PR DESCRIPTION
Dear @proddata, @mechanomi and @infoverload,

this implements @proddata's suggestions from [1] - thanks for that! It delivers short titles for the navigation on the left hand side but fully verbose titles on the respective pages. The way to do it like that with Sphinx will hopefully make both SEO and our users' eyes more happy.

With kind regards,
Andreas.

P.S.: I didn't scan other parts of the documentation yet, but it can well be expanded to every spot where this makes sense to improve user experience right away without any significant efforts.

P.P.S.: I made this change blindly without running Sphinx on that. Nevertheless, I hope everything will turn out well. @crate/tech-writing: Please adjust wording and stuff if you like, I just took the labels verbatim from the left hand side of the screenshot @proddata shared the other day [2].

[1] https://crate.slack.com/archives/CQ3NEU05A/p1602250372005200
[2] ![image](https://user-images.githubusercontent.com/453543/96593058-62d8fe00-12e9-11eb-9e41-d5f6e4b6fb3a.png)
