### PR TITLE
Minor copyedit for files, including removal of :last-reviewed: metadata

### DIFF
--- a/docs/admin/bootstrap-checks.rst
+++ b/docs/admin/bootstrap-checks.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-07-01
-
 .. highlight:: sh
 
 .. _bootstrap-checks:
@@ -31,14 +28,17 @@ run, but it is still a good idea to follow these instructions.
 .. contents::
    :local:
 
+
 System settings
 ===============
+
 
 Official packages
 -----------------
 
 If you are using one of the official packages, all of the necessary operating
 system configuration is handled for you.
+
 
 Tarball
 -------
@@ -63,6 +63,7 @@ Here's what needs to be configured:
 You might be able to set these limits per process or per user, depending on
 your operating system and setup. And for this to take effect, you may also have
 to set these limits for the superuser.
+
 
 Linux
 .....
@@ -109,6 +110,7 @@ This command will this reload all settings from ``/etc/sysctl.conf``.
     Note, however, this setting will be reset to the value in
     ``/etc/sysctl.conf`` when your system next boots.
 
+
 Garbage collection
 ==================
 
@@ -118,11 +120,11 @@ including CrateDB 4.0) and `G1GC`_ (the default with CrateDB 4.1).
 `G1GC` can also be used in earlier CrateDB versions, but should only be used in
 combination with Java 11 or later.
 
-
 .. WARNING::
 
    Other garbage collectors have not been tested with CrateDB and we do not
    support using other GCs in production.
+
 
 .. _CMS garbage collector: https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html
 .. _G1GC: https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm

--- a/docs/best-practices/data-import.rst
+++ b/docs/best-practices/data-import.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-09-29
-
 .. highlight:: psql
 
 .. _efficient_data_import:
@@ -8,9 +5,6 @@
 ====================================
 Importing huge datasets into CrateDB
 ====================================
-
-Introduction
-============
 
 Projects often contain pre-existing data that needs to be imported and
 sometimes the amount of data is significant.
@@ -32,6 +26,7 @@ import your data quickly and safely.
 
 Configuring your tables
 =======================
+
 
 Defining the data structure
 ---------------------------
@@ -158,6 +153,7 @@ Importing the data
 ==================
 
 Once the table is created, you can start importing the data.
+
 
 JSON import format
 ------------------
@@ -371,14 +367,15 @@ Further reading
 
   - `Import/Export`_
 
+
+.. _Alter a partitioned table: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter
+.. _ALTER TABLE ONLY: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter-table-only
 .. _CLUSTERED clause: http://crate.io/docs/crate/reference/sql/reference/create_table.html#clustered-clause
-.. _Replication: https://crate.io/docs/crate/reference/sql/ddl/replication.html#replication
-.. _Refresh: https://crate.io/docs/crate/reference/sql/refresh.html
+.. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
+.. _Import/Export: https://crate.io/docs/crate/reference/sql/dml.html#import-export
+.. _PARTITIONED BY clause: https://crate.io/docs/crate/reference/sql/reference/create_table.html#partitioned-by-clause
+.. _partitioned tables: https://crate.io/docs/crate/reference/sql/partitioned_tables.html
 .. _refresh interval: https://crate.io/docs/crate/reference/sql/refresh.html
 .. _refresh_interval: https://crate.io/docs/crate/reference/sql/reference/create_table.html#refresh-interval
-.. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
-.. _ALTER TABLE ONLY: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter-table-only
-.. _partitioned tables: https://crate.io/docs/crate/reference/sql/partitioned_tables.html
-.. _PARTITIONED BY clause: https://crate.io/docs/crate/reference/sql/reference/create_table.html#partitioned-by-clause
-.. _Alter a partitioned table: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter
-.. _Import/Export: https://crate.io/docs/crate/reference/sql/dml.html#import-export
+.. _Refresh: https://crate.io/docs/crate/reference/sql/refresh.html
+.. _Replication: https://crate.io/docs/crate/reference/sql/ddl/replication.html#replication

--- a/docs/best-practices/migrating-from-mongodb.rst
+++ b/docs/best-practices/migrating-from-mongodb.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-31
-
 .. highlight:: psql
 
 ======================
@@ -135,9 +132,10 @@ After the table has been created the file can be imported using
 There is an entire section dedicated on how to do a data import efficiently.
 Continue reading there: :ref:`efficient_data_import`.
 
-.. _Indices and Fulltext Search: https://crate.io/docs/crate/reference/sql/ddl/indices_full_search.html
-.. _Data Definition: https://crate.io/docs/crate/reference/sql/ddl/index.html
-.. _CREATE TABLE: https://crate.io/docs/crate/reference/sql/reference/create_table.html
+
 .. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
+.. _CREATE TABLE: https://crate.io/docs/crate/reference/sql/reference/create_table.html
+.. _Data Definition: https://crate.io/docs/crate/reference/sql/ddl/index.html
+.. _Indices and Fulltext Search: https://crate.io/docs/crate/reference/sql/ddl/indices_full_search.html
 .. _MongoDB Extended JSON: http://docs.mongodb.org/manual/reference/mongodb-extended-json/
 .. _MongoDB migration tool: https://github.com/crate/mongodb-cratedb-migration-tool

--- a/docs/best-practices/migrating-from-mysql.rst
+++ b/docs/best-practices/migrating-from-mysql.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-09-29
-
 .. highlight:: psql
 
 .. _migrating_from_mysql:
@@ -8,9 +5,6 @@
 ====================
 Migrating from MySQL
 ====================
-
-Introduction
-============
 
 Various ways exist to migrate your existing data from MySQL_ to CrateDB_.
 However, these methods may differ in performance. A fast and reliable way to
@@ -20,6 +14,7 @@ migrate is to use CrateDB's existing export and import tools.
 
 .. contents::
    :local:
+
 
 Setting up the example table
 ============================
@@ -140,9 +135,10 @@ For example:
   See also the documentation of `csvsql`_. To use the SQLAlchemy driver of
   CrateDB, the latest version of the `CrateDB Python package`_ is required.
 
-.. _MySQL: http://mysql.com
+
 .. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
+.. _CrateDB Python package: https://pypi.python.org/pypi/crate
 .. _CrateDB: https://crate.io
 .. _csvkit: https://csvkit.readthedocs.io/en/540/index.html
 .. _csvsql: https://csvkit.readthedocs.io/en/540/scripts/csvsql.html
-.. _CrateDB Python package: https://pypi.python.org/pypi/crate
+.. _MySQL: http://mysql.com

--- a/docs/clustering/index.rst
+++ b/docs/clustering/index.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _clustering:
 
 ==========

--- a/docs/clustering/kubernetes.rst
+++ b/docs/clustering/kubernetes.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _scaling-kube:
 
 =============================
@@ -34,6 +31,7 @@ Together, Docker and Kubernetes are a fantastic way to deploy and scale CrateDB.
 .. contents::
    :local:
 
+
 .. _scaling-kube-kube:
 
 Kubernetes reconfiguration
@@ -42,6 +40,7 @@ Kubernetes reconfiguration
 You can scale your CrateDB cluster by increasing or decreasing the configured
 number of replica `pods`_ in your `StatefulSet`_ controller to the desired
 number of CrateDB nodes.
+
 
 .. _scaling-kube-command:
 
@@ -59,6 +58,7 @@ so:
 
     This makes it easy to scale quickly, but your cluster configuration is not
     reflected in your `version control`_ system.
+
 
 .. _scaling-kube-vc:
 
@@ -112,6 +112,7 @@ restart your pods with the new configuration one-by-one.
     resources are deleted and recreated, and the pods will come back up with no
     data.
 
+
 .. _scaling-kube-cratedb:
 
 CrateDB reconfiguration
@@ -127,6 +128,7 @@ CrateDB cluster.
 
     You should take particular care if you are reducing the size of the cluster
     because CrateDB must recover and rebalance shards as the nodes drop out.
+
 
 .. _scaling-kube-clustering:
 
@@ -167,6 +169,7 @@ Control`_.
     Accordingly, it is important to `adjust this number carefully`_ when
     scaling CrateDB.
 
+
 .. _scaling-kube-recovery:
 
 Recovery behavior
@@ -198,6 +201,7 @@ Control`_.
 
     However, you should only do this on a production cluster if you need to
     scale to handle a load spike quickly.
+
 
 .. _adjust this number carefully: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#minimum-master-nodes
 .. _containerization: https://www.docker.com/resources/what-container

--- a/docs/clustering/multi-node-setup.rst
+++ b/docs/clustering/multi-node-setup.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _multi_node_setup:
 
 ========================
@@ -39,6 +36,7 @@ This process is only necessary the first time a cluster starts because:
 
 - new nodes that need to join a cluster will obtain this information from the
   cluster's elected master node
+
 
 .. _auto-bootstrapping:
 
@@ -174,6 +172,7 @@ auto-bootstrapping).
 
 Node discovery
 ^^^^^^^^^^^^^^
+
 
 Seeding manually
 """"""""""""""""
@@ -480,12 +479,12 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 .. _discovery.zen.minimum_master_nodes: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
 .. _discovery.zen.ping.unicast.hosts: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#unicast-host-discovery
 .. _DNS: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-via-dns
+.. _elects the master node: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html#master-node-election
 .. _full cluster restarts: https://crate.io/docs/crate/howtos/en/latest/admin/full-restart-upgrade.html
 .. _gateway.expected_nodes: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#gateway-expected-nodes
 .. _gateway.recover_after_nodes: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#gateway-recover-after-nodes
 .. _hostname: https://en.wikipedia.org/wiki/Hostname
 .. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
-.. _elects the master node: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html#master-node-election
 .. _Metadata configuration settings: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata
 .. _metadata gateway: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata-gateway
 .. _Microsoft Azure: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-on-microsoft-azure

--- a/docs/clustering/multi-zone-setup.rst
+++ b/docs/clustering/multi-zone-setup.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _multi-zone-setup:
 
 ========================
@@ -27,6 +24,7 @@ to set up a multi-zone CrateDB cluster.
 .. contents::
    :local:
 
+
 .. _multi-zone-requirements:
 
 Multi-zone requirements
@@ -46,6 +44,7 @@ To achieve these requirements, make use of `shard allocation awareness`_, which
 allows you to configure `shard`_ and replica allocation. If you are new to setting
 up a multi-node CrateDB cluster, you should read our :ref:`multi-node setup
 <multi_node_setup>` guide first.
+
 
 .. _tag-assignments:
 
@@ -86,6 +85,7 @@ For example:
 
    These tags and settings cannot be changed at runtime and need to be
    set on startup.
+
 
 .. _allocation-awareness:
 
@@ -142,6 +142,7 @@ still allocate the replicas on nodes with the same ``zone`` value to avoid
    awareness attributes. To avoid such allocations, you can :ref:`force the
    awareness <force-awareness>`.
 
+
 .. _force-awareness:
 
 Force awareness
@@ -185,16 +186,17 @@ zones and regions. However, be aware of the drawbacks that a multi-region
 setup can have. These include latency and also security issues between
 non-encrypted node-to-node traffic if the traffic escapes a "trusted" network.
 
+
 .. _awareness: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#awareness
+.. _configuration guide: https://crate.io/docs/reference/configuration.html
+.. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _CrateDB Shell: https://crate.io/docs/crate/crash/en/latest/
 .. _create a table: https://crate.io/docs/crate/reference/en/latest/general/ddl/create-table.html
-.. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
-.. _configuration guide: https://crate.io/docs/reference/configuration.html
 .. _node custom attributes: https://crate.io/docs/crate/reference/en/latest/config/node.html#custom-attributes
 .. _replica: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
 .. _replicas: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
+.. _shard allocation awareness: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#awareness
 .. _shard: https://crate.io/docs/crate/reference/en/latest/general/ddl/sharding.html
 .. _shards: https://crate.io/docs/crate/reference/en/latest/general/ddl/sharding.html
-.. _shard allocation awareness: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#awareness
 .. _unassigned shards: https://crate.io/docs/crate/howtos/en/latest/performance/sharding.html#under-allocation-is-bad
 .. _write operation: https://crate.io/docs/crate/reference/en/latest/concepts/storage-consistency.html#data-storage

--- a/docs/deployment/containers/docker.rst
+++ b/docs/deployment/containers/docker.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. highlight:: sh
 
 .. _cratedb-docker:
@@ -31,8 +28,10 @@ This document covers the essentials of running CrateDB on Docker.
 .. contents::
    :local:
 
+
 Quick start
 ===========
+
 
 Creating a cluster
 ------------------
@@ -200,6 +199,7 @@ Success! You just created a three-node CrateDB cluster with Docker.
    in the admin UI. For a more robust cluster, you should, at the very least,
    configure the `Metadata Gateway`_ and `Discovery`_ settings.
 
+
 .. _docker-troubleshooting:
 
 Troubleshooting
@@ -235,6 +235,7 @@ You can also start a single node without any bootstrap checks by passing the
 
    This means that the node cannot form a cluster with any other nodes.
 
+
 Taking it further
 -----------------
 
@@ -243,6 +244,7 @@ using the ``-C`` flag, as shown in the examples above.
 
 Check out the `Docker docs <https://docs.docker.com/engine/reference/run/>`_
 for more Docker-specific features that CrateDB can leverage.
+
 
 CrateDB Shell
 -------------
@@ -256,6 +258,7 @@ and connect to three hosts named ``crate01``, ``crate02``, and ``crate03``
     $ docker run --rm -ti \
         --net=crate crate \
         crash --hosts crate01 crate02 crate03
+
 
 .. _docker-compose:
 
@@ -357,8 +360,10 @@ In the file above:
 - The start order of the containers is not deterministic and you want all
   three containers to be up and running before the election of the master node.
 
+
 Best Practices
 ==============
+
 
 One container per host
 ----------------------
@@ -371,6 +376,7 @@ to the host ports so that the host acts like a native installation. For example:
 
     $ docker run -d -p 4200:4200 -p 4300:4300 -p 5432:5432 crate \
         crate -Cnetwork.host=_site_
+
 
 Persistent data directory
 -------------------------
@@ -388,6 +394,7 @@ path to your host machine's ``data`` directory.
 
 See the `Docker volume`_ documentation for more help.
 
+
 Custom configuration
 --------------------
 
@@ -404,6 +411,7 @@ Here is an example of how you could mount the ``crate.yml`` config file::
 
 Here, ``/srv/crate/config/crate.yml`` is an example path, and should be
 replaced with the path to your host machine's ``crate.yml`` file.
+
 
 Troubleshooting
 ===============
@@ -424,6 +432,7 @@ You can do that by editing your `Docker Stack YAML file`_:
     healthcheck:
       disable: true
 
+
 .. _resource_constraints:
 
 Resource constraints
@@ -443,6 +452,7 @@ during bootstrap. The settings listed in `Bootstrap Checks`_ must be addressed o
 the Docker **host system** in order to start CrateDB successfully and when
 `going into production`_.
 
+
 Memory
 ------
 
@@ -456,12 +466,14 @@ which in turn passes it to the JVM.
 
 It is not necessary to configure swap memory since CrateDB does not use swap.
 
+
 CPU
 ---
 
 You must calculate and explicitly `set the maximum number of CPUs`_ that the
 container can use. This is dependent on your host system and should typically
 be as high as possible.
+
 
 Combined configuration
 ----------------------
@@ -476,6 +488,7 @@ example::
         --env CRATE_HEAP_SIZE=1g \
         crate \
         crate -Cnetwork.host=_site_
+
 
 .. _Bootstrap Checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
 .. _compose file version: https://docs.docker.com/compose/compose-file/compose-versioning/

--- a/docs/deployment/containers/kubernetes.rst
+++ b/docs/deployment/containers/kubernetes.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _cratedb-kubernetes:
 
 =========================
@@ -37,6 +34,7 @@ Together, Docker and Kubernetes are a fantastic way to deploy and scale CrateDB.
 .. contents::
    :local:
 
+
 Prerequisites
 =============
 
@@ -51,6 +49,7 @@ with at least one master node and one worker node.
 
    Alternatively, cloud services such as `Azure Kubernetes Service`_ or the
    `Amazon Kubernetes Service`_ can do this for you.
+
 
 Managing Kubernetes
 ===================
@@ -90,11 +89,13 @@ restart your pods with the new configuration one-by-one.
     resources are deleted and recreated, and the pods will come back up with no
     data.
 
+
 Configuration
 =============
 
 This section provides four Kubernetes `configuration`_ snippets that can be
 used to create a three-node CrateDB cluster.
+
 
 Services
 --------
@@ -109,6 +110,7 @@ constituent pods may come and go.
 
 For our purposes, we define two services: an `internal service`_ and an
 `external service`_.
+
 
 Internal service
 ................
@@ -137,6 +139,7 @@ Here's an example configuration snippet:
       selector:
         # Apply this to all nodes with the `app:crate` label.
         app: crate
+
 
 External service
 ................
@@ -175,6 +178,7 @@ Here's an example configuration snippet:
    load balancers.
 
    For local development, `Minikube`_ provides a LoadBalancer service.
+
 
 Controller
 ----------
@@ -320,6 +324,7 @@ CrateDB 3.0.5 cluster:
    You must set memory map limits correctly. Consult the :ref:`bootstrap checks
    <bootstrap-checks>` documentation for more information.
 
+
 Persistent volume
 -----------------
 
@@ -329,6 +334,7 @@ with `persistent volumes`_.
 
 There are many different ways to provide persistent volumes, and so the specific
 configuration will depend on your setup.
+
 
 Microsoft Azure
 ...............
@@ -373,6 +379,7 @@ You can then use this in your controller configuration with something like this:
             resources:
               requests:
                 storage: 100g
+
 
 .. _Amazon Kubernetes Service: https://aws.amazon.com/eks/
 .. _Azure Kubernetes Service: https://azure.microsoft.com/en-us/services/kubernetes-service/

--- a/docs/deployment/linux/debian.rst
+++ b/docs/deployment/linux/debian.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-21
-
 .. _debian:
 
 ===============================
@@ -35,6 +32,7 @@ the CrateDB Debian package.
 
 .. contents::
    :local:
+
 
 Configure Apt
 =============
@@ -116,6 +114,7 @@ You should be able to access it by visiting::
 
 .. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
 
+
 Controlling CrateDB
 ===================
 
@@ -135,14 +134,17 @@ so on.
     :ref:`full restart upgrades <full_restart_upgrade>` before attempting to
     upgrade a running cluster.
 
+
 Configuration
 =============
+
 
 Configuration files
 -------------------
 
 The main CrateDB `configuration files`_ are located in the ``/etc/crate``
 directory.
+
 
 Environment
 -----------
@@ -170,6 +172,7 @@ Here's one example:
 
    # Force the JVM to use IPv4 stack
    CRATE_USE_IPV4=true
+
 
 Customized setups
 =================

--- a/docs/deployment/linux/red-hat.rst
+++ b/docs/deployment/linux/red-hat.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-07-17
-
 .. _red-hat:
 
 ============================
@@ -19,6 +16,7 @@ Both of these work with RedHat Enterprise Linux, CentOS, and Scientific Linux.
 
 .. contents::
    :local:
+
 
 Configure YUM
 =============
@@ -59,6 +57,7 @@ This is because the testing repository's configuration marks it as disabled.
 If you would like to enable to testing repository, open the ``crate.repo`` file
 and set ``enabled=1`` under the ``[crate-testing]`` section.
 
+
 Install CrateDB
 ===============
 
@@ -69,6 +68,7 @@ With everything set up, you can install CrateDB, like so:
    yum install crate
 
 CrateDB is now installed, but not running.
+
 
 Running and controlling CrateDB
 ===============================
@@ -101,14 +101,17 @@ You should be able to access it by visiting::
     :ref:`full restart upgrades <full_restart_upgrade>` before attempting to
     upgrade a running cluster.
 
+
 Configuration
 =============
+
 
 Configuration files
 -------------------
 
 The main CrateDB configuration files are located in the ``/etc/crate``
 directory.
+
 
 Environment
 -----------
@@ -141,6 +144,7 @@ Here's one example:
    # Force the JVM to use IPv4 stack
    CRATE_USE_IPV4=true
 
+
 Customized setups
 =================
 
@@ -150,5 +154,6 @@ A full list of package files can be obtained with this command::
 
 If you want to deviate from the way that the ``crate`` package integrates with
 your system, we recommend that you go with a `basic tarball installation`_.
+
 
 .. _basic tarball installation: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html

--- a/docs/deployment/linux/ubuntu.rst
+++ b/docs/deployment/linux/ubuntu.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-07-09
-
 .. _ubuntu:
 
 =====================
@@ -15,12 +12,13 @@ CrateDB maintains packages for the following versions:
 - `Ubuntu 14.04.6`_ (Trusty Tahr)
 
 This guide will show you how to install, control, and configure a single-node
-CrateDB on a local Ubuntu system. 
+CrateDB on a local Ubuntu system.
+
 
 Prerequisites
 =============
 
-CrateDB requires a `Java virtual machine`_ (JVM) to run. 
+CrateDB requires a `Java virtual machine`_ (JVM) to run.
 
 CrateDB versions 4.2+ include a JVM and do not require a separate Java
 installation. You can skip to :ref:`install CrateDB`.
@@ -28,7 +26,7 @@ installation. You can skip to :ref:`install CrateDB`.
 Earlier CrateDB versions require Java 11 to be installed. To run CrateDB on
 Ubuntu releases older than 18.04, you need to install Java from a third-party
 repository. This can be done by adding the `OpenJDK`_ PPA (Personal Package
-Archive): 
+Archive):
 
 .. code-block:: sh
 
@@ -62,7 +60,7 @@ CrateDB repositories:
 
    CrateDB provides a *stable release* and a *testing release* channel. To use
    the testing channel, replace ``stable`` with ``testing`` in the command
-   above. You can read more about our `release workflow`_. 
+   above. You can read more about our `release workflow`_.
 
 
 Now update Apt:
@@ -92,6 +90,7 @@ visiting::
    cluster and you won't be able to add additional nodes. In order to form a
    multi-node cluster, you will need to remove the cluster state after
    changing the configuration.
+
 
 Control CrateDB
 ===============
@@ -126,6 +125,7 @@ Configure CrateDB
 
 In order to configure CrateDB, take note of the configuration file
 location and the available environment variables.
+
 
 Configuration files
 -------------------

--- a/docs/going-into-production.rst
+++ b/docs/going-into-production.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-08-17
-
 .. _going-into-production:
 
 =====================

--- a/docs/integrations/ml-dist.rst
+++ b/docs/integrations/ml-dist.rst
@@ -1,15 +1,8 @@
-.. meta::
-    :last-reviewed: 2020-07-13
-
 .. _cratedb-distributed-ml:
 
 =====================================================
 Distributed Deep-Learning with CrateDB and TensorFlow
 =====================================================
-
-
-Abstract
-========
 
 Using deep learning algorithms for Machine Learning use cases has become more
 and more common in the world of data science. A common library used for solving
@@ -541,18 +534,18 @@ pipeline. The training and prediction stages are decoupled, and can be
 distributed across different machines, contexts, and scenarios.
 
 
-.. _TensorFlow: https://www.tensorflow.org/
-.. _Psycopg2: https://pypi.org/project/psycopg2/
-.. _Pandas: https://pandas.pydata.org/
-.. _Sklearn: https://scikit-learn.org/stable/
-.. _Kaggle: https://www.kaggle.com/
-.. _pump_sensor_data: https://www.kaggle.com/nphantawee/pump-sensor-data
 .. _A running CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
 .. _An AWS S3 storage bucket: https://aws.amazon.com/s3/
-.. _Python: https://www.python.org/
-.. _numpy: https://numpy.org/
-.. _Multilayer Perceptron: https://en.wikipedia.org/wiki/Multilayer_perceptron
-.. _ReLU: https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
 .. _boto3: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html
 .. _joblib: https://joblib.readthedocs.io/en/latest/index.html
+.. _Kaggle: https://www.kaggle.com/
 .. _matplotlib: https://matplotlib.org/
+.. _Multilayer Perceptron: https://en.wikipedia.org/wiki/Multilayer_perceptron
+.. _numpy: https://numpy.org/
+.. _Pandas: https://pandas.pydata.org/
+.. _Psycopg2: https://pypi.org/project/psycopg2/
+.. _pump_sensor_data: https://www.kaggle.com/nphantawee/pump-sensor-data
+.. _Python: https://www.python.org/
+.. _ReLU: https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
+.. _Sklearn: https://scikit-learn.org/stable/
+.. _TensorFlow: https://www.tensorflow.org/

--- a/docs/integrations/streamsets.rst
+++ b/docs/integrations/streamsets.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-09-10
-
 .. _cratedb-streamsets:
 
 ================================================================
@@ -151,11 +148,11 @@ You can verify that the data is now in CrateDB:
     +----------+--------------------+--------------------+
     SELECT 1 row in set (0.050 sec)
 
-.. _StreamSets Data Collector: https://streamsets.com/products/dataops-platform/data-collector/
-.. _CrateDB JDBC driver: https://crate.io/docs/jdbc/en/latest/
-.. _New York taxi dataset: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Tutorial/BeforeYouBegin.html?hl=nyc_taxi_data/
+
 .. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
 .. _A running and accessable StreamSets Data Collector: https://streamsets.com/products/dataops-platform/data-collector/download/
 .. _Bintray Repository: https://bintray.com/crate/crate/crate-jdbc/view/files/io/crate/crate-jdbc-standalone/#files/io/crate/crate-jdbc-standalone/
+.. _CrateDB JDBC driver: https://crate.io/docs/jdbc/en/latest/
 .. _external libraries: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Configuration/ExternalLibs.html
-
+.. _New York taxi dataset: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Tutorial/BeforeYouBegin.html?hl=nyc_taxi_data/
+.. _StreamSets Data Collector: https://streamsets.com/products/dataops-platform/data-collector/

--- a/docs/performance/memory.rst
+++ b/docs/performance/memory.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-07-01
-
 .. _memory:
 
 ====================
@@ -45,6 +42,7 @@ it shouldn't be set above 30.5GB, see the limits section below.
 
 .. contents::
    :local:
+
 
 .. _memory-limits:
 
@@ -94,6 +92,7 @@ offset the memory lost due to the lack of *Compressed Oops*.
     When configuring heap size via `CRATE_HEAP_SIZE`_, you can specify 30.5
     gigabytes with the value ``30500m``.
 
+
 .. _swap:
 
 Swap
@@ -108,6 +107,8 @@ like so:
 
       bootstrap.memory_lock: true
 
+
+.. _bootstrap.memory_lock: https://crate.io/docs/crate/reference/en/latest/config/node.html#memory
 .. _Compressed Oops: https://wiki.openjdk.java.net/display/HotSpot/CompressedOops
 .. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _configurations: https://crate.io/docs/crate/reference/en/latest/config/index.html
@@ -117,5 +118,4 @@ like so:
 .. _HotSpot Java Virtual Machine: http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136373.html
 .. _Lucene: https://lucene.apache.org/
 .. _Memory mapped files: https://en.wikipedia.org/wiki/Memory-mapped_file
-.. _bootstrap.memory_lock: https://crate.io/docs/crate/reference/en/latest/config/node.html#memory
 .. _x64 architectures: https://en.wikipedia.org/wiki/X86-64

--- a/docs/reference-architectures/distributed-ml.rst
+++ b/docs/reference-architectures/distributed-ml.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-07-13
-
 ========================================
 Distributed Machine Learning At The Edge
 ========================================
@@ -45,5 +42,6 @@ This architecture makes use of the following components and CrateDB integrations
 6. Prometheus `Alertmanager`_ triggering an alert to users if the prediction
    layer's predictions fall within dangerous thresholds.
 
-.. _Prometheus: https://www.prometheus.io
+
 .. _Alertmanager: https://www.prometheus.io/docs/alerting/latest/alertmanager/
+.. _Prometheus: https://www.prometheus.io

--- a/docs/troubleshooting/docker-jcmd.rst
+++ b/docs/troubleshooting/docker-jcmd.rst
@@ -1,6 +1,3 @@
-.. meta::
-    :last-reviewed: 2020-09-07
-
 .. _jcmd-docker:
 
 ===============================================
@@ -212,6 +209,7 @@ Thread Dump
 
 :Command: ``jcmd <PID> Thread.print``
 
+
 Example
 .......
 
@@ -227,6 +225,7 @@ Heap Info
 
 :Command: ``jcmd <PID> GC.heap_info``
 
+
 Example
 .......
 
@@ -241,6 +240,7 @@ Heap Dump
 ---------
 
 :Command: ``jcmd <PID> GC.heap_dump <PATH>``
+
 
 Example
 .......
@@ -262,6 +262,7 @@ Java Flight Recording
 ---------------------
 
 :Command: ``jcmd <PID> JFR.start name=<NAME> duration=<DURATION> filename=<PATH> settings=profile``
+
 
 Example
 .......


### PR DESCRIPTION
Previously, the :last-reviewed: metadata was added to indicate that these files
received a content refresh.

Per <https://github.com/crate/tech-writing-domain/issues/360>, we are now using
Git commit keywords.
