### PR TITLE
Fix link errors (as reported by sphinx-build -b linkcheck)

### DIFF
--- a/docs/admin/full-restart-upgrade.rst
+++ b/docs/admin/full-restart-upgrade.rst
@@ -63,6 +63,6 @@ Once the CrateDB software on node in the cluster has been updated, start the
 appropriate to your setup.
 
 .. _Arch Linux AUR package: https://aur.archlinux.org/packages/crate/
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _install: https://crate.io/docs/install/local/linux/
 .. _release directory: https://cdn.crate.io/downloads/releases/

--- a/docs/admin/rolling-upgrade.rst
+++ b/docs/admin/rolling-upgrade.rst
@@ -53,10 +53,6 @@ Using ``none``, there is no data-availability guarantee. The node will stop,
 possibly leaving the cluster in the critical ``red`` state if the node
 contained a primary that has no replicas that can take over.
 
-.. CAUTION::
-
-   If you are upgrading from 0.54 to 0.55, please read the `accompanying
-   notes`_ for the 0.55 release.
 
 Requirements
 ============
@@ -279,11 +275,11 @@ again that have been disabled in the first step:
   cr> SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = 'all';
   SET OK, 1 row affected (... sec)
 
-.. _accompanying notes: https://crate.io/a/upgrade-your-cluster-to-0-55/
-.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
-.. _versions: https://crate.io/docs/crate/reference/sql/system.html#version
-.. _release notes: https://crate.io/docs/crate/reference/release_notes/index.html
-.. _Signal Handling: https://crate.io/docs/crate/reference/cli.html#signal-handling
-.. _SET: https://crate.io/docs/crate/reference/sql/reference/set.html
-.. _Graceful Stop: https://crate.io/docs/crate/reference/configuration.html#graceful-stop
+
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+.. _versions: https://crate.io/docs/crate/reference/en/latest/sql/system.html#version
+.. _release notes: https://crate.io/docs/crate/reference/en/latest/appendices/release-notes/index.html
+.. _Signal Handling: https://crate.io/docs/crate/reference/en/latest/cli-tools.html#signal-handling
+.. _SET: https://crate.io/docs/crate/reference/en/latest/sql/statements/set.html
+.. _Graceful Stop: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#graceful-stop
 .. _Decommission Statement: https://crate.io/docs/crate/reference/en/latest/sql/statements/alter-cluster.html#decommission-nodeid-nodename

--- a/docs/best-practices/data-import.rst
+++ b/docs/best-practices/data-import.rst
@@ -368,14 +368,14 @@ Further reading
   - `Import/Export`_
 
 
-.. _Alter a partitioned table: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter
-.. _ALTER TABLE ONLY: https://crate.io/docs/crate/reference/sql/partitioned_tables.html#alter-table-only
-.. _CLUSTERED clause: http://crate.io/docs/crate/reference/sql/reference/create_table.html#clustered-clause
-.. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
-.. _Import/Export: https://crate.io/docs/crate/reference/sql/dml.html#import-export
-.. _PARTITIONED BY clause: https://crate.io/docs/crate/reference/sql/reference/create_table.html#partitioned-by-clause
-.. _partitioned tables: https://crate.io/docs/crate/reference/sql/partitioned_tables.html
-.. _refresh interval: https://crate.io/docs/crate/reference/sql/refresh.html
-.. _refresh_interval: https://crate.io/docs/crate/reference/sql/reference/create_table.html#refresh-interval
-.. _Refresh: https://crate.io/docs/crate/reference/sql/refresh.html
-.. _Replication: https://crate.io/docs/crate/reference/sql/ddl/replication.html#replication
+.. _Alter a partitioned table: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html#alter
+.. _ALTER TABLE ONLY: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html#alter-table-only
+.. _CLUSTERED clause: https://crate.io/docs/crate/reference/en/latest/sql/statements/create-table.html#clustered
+.. _COPY FROM: https://crate.io/docs/crate/reference/en/latest/sql/reference/copy_from.html
+.. _Import/Export: https://crate.io/docs/crate/reference/en/latest/general/dml.html#import-and-export
+.. _PARTITIONED BY clause: https://crate.io/docs/crate/reference/en/latest/sql/reference/create_table.html#partitioned-by-clause
+.. _partitioned tables: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html
+.. _refresh interval: https://crate.io/docs/crate/reference/en/latest/sql/refresh.html
+.. _refresh_interval: https://crate.io/docs/crate/reference/en/latest/sql/reference/create_table.html#refresh-interval
+.. _Refresh: https://crate.io/docs/crate/reference/en/latest/sql/refresh.html
+.. _Replication: https://crate.io/docs/crate/reference/en/latest/sql/ddl/replication.html#replication

--- a/docs/best-practices/migrating-from-mongodb.rst
+++ b/docs/best-practices/migrating-from-mongodb.rst
@@ -137,5 +137,5 @@ Continue reading there: :ref:`efficient_data_import`.
 .. _CREATE TABLE: https://crate.io/docs/crate/reference/sql/reference/create_table.html
 .. _Data Definition: https://crate.io/docs/crate/reference/sql/ddl/index.html
 .. _Indices and Fulltext Search: https://crate.io/docs/crate/reference/sql/ddl/indices_full_search.html
-.. _MongoDB Extended JSON: http://docs.mongodb.org/manual/reference/mongodb-extended-json/
+.. _MongoDB Extended JSON: https://docs.mongodb.com/manual/reference/mongodb-extended-json/
 .. _MongoDB migration tool: https://github.com/crate/mongodb-cratedb-migration-tool

--- a/docs/best-practices/migrating-from-mysql.rst
+++ b/docs/best-practices/migrating-from-mysql.rst
@@ -74,13 +74,12 @@ when read from the convert script later.
 Converting date/time types
 --------------------------
 
-The standard output for `date/time types in MySQL
-<http://dev.mysql.com/doc/refman/5.0/en/date-and-time-types.html>`_ is a
-string. However, CrateDB uses a ``long`` type to store timestamps (with
-millisecond precision). To prevent problems with dates that have timezone
-information, use MySQL's builtin ``UNIX_TIMESTAMP`` function to convert
-``date``, ``time``, ``datetime``, ``timestamp`` and ``year`` types into UNIX
-timestamps directly in the ``SELECT`` statement.
+The standard output for `date/time types in MySQL`_ is a string. However,
+CrateDB uses a ``long`` type to store timestamps (with millisecond precision).
+To prevent problems with dates that have timezone information, use MySQL's
+builtin ``UNIX_TIMESTAMP`` function to convert ``date``, ``time``,
+``datetime``, ``timestamp`` and ``year`` types into UNIX timestamps directly in
+the ``SELECT`` statement.
 
 The output of this function must be multiplied by ``1000`` (converting ``s`` to
 ``ms``) to obtain the correct ``long`` value that can be used for importing
@@ -137,8 +136,9 @@ For example:
 
 
 .. _COPY FROM: https://crate.io/docs/crate/reference/sql/reference/copy_from.html
-.. _CrateDB Python package: https://pypi.python.org/pypi/crate
-.. _CrateDB: https://crate.io
+.. _CrateDB Python package: https://pypi.org/project/crate/
+.. _CrateDB: https://crate.io/
 .. _csvkit: https://csvkit.readthedocs.io/en/540/index.html
 .. _csvsql: https://csvkit.readthedocs.io/en/540/scripts/csvsql.html
-.. _MySQL: http://mysql.com
+.. _date/time types in MySQL: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-types.html
+.. _MySQL: https://www.mysql.com/

--- a/docs/best-practices/systables.rst
+++ b/docs/best-practices/systables.rst
@@ -300,4 +300,4 @@ to restore. Suppose you make nightly backups, the command::
 shows you last week's snapshots along with their name, the stored indices, and
 how long they took.
 
-.. _`reference documentation about system tables`: https://crate.io/docs/crate/reference/sql/system.html#Allocations
+.. _reference documentation about system tables: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#allocations

--- a/docs/clustering/kubernetes.rst
+++ b/docs/clustering/kubernetes.rst
@@ -203,17 +203,17 @@ Control`_.
     scale to handle a load spike quickly.
 
 
-.. _adjust this number carefully: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#minimum-master-nodes
+.. _adjust this number carefully: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
 .. _containerization: https://www.docker.com/resources/what-container
-.. _CrateDB Admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
+.. _CrateDB Admin UI: https://crate.io/docs/crate/admin-ui/en/latest/
 .. _CrateDB Docker image: https://hub.docker.com/_/crate/
 .. _deleted and recreated: https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#disruptive-updates
-.. _discovery.zen.minimum_master_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#minimum-master-nodes
+.. _discovery.zen.minimum_master_nodes: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
 .. _Docker: https://www.docker.com/
 .. _gateway.expected_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-expected-nodes
 .. _gateway.recover_after_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-after-nodes
-.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling
-.. _imperative command: https://kubernetes.io/docs/concepts/overview/object-management-kubectl/overview/#imperative-commands
+.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_(scale_out)_and_vertical_scaling_(scale_up)
+.. _imperative command: https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/#imperative-commands
 .. _kubectl: https://kubernetes.io/docs/reference/kubectl/overview/
 .. _Kubernetes: https://kubernetes.io/
 .. _metadata master: https://crate.io/docs/crate/guide/en/latest/architecture/shared-nothing.html#cluster-state-management
@@ -221,7 +221,7 @@ Control`_.
 .. _namespace: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 .. _node check: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#description-of-checked-node-settings
 .. _persistent volumes: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-.. _pods: https://kubernetes.io/docs/concepts/workloads/pods/pod/
+.. _pods: https://kubernetes.io/docs/concepts/workloads/pods/
 .. _rolling update strategy: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates
 .. _runtime configuration: https://crate.io/docs/crate/reference/en/latest/admin/runtime-config.html#administration-runtime-config
 .. _shared-nothing architecture : https://en.wikipedia.org/wiki/Shared-nothing_architecture

--- a/docs/clustering/multi-node-setup.rst
+++ b/docs/clustering/multi-node-setup.rst
@@ -463,7 +463,7 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 
 .. _127.0.0.1:4200: http://127.0.0.1:4200/
 .. _127.0.0.1:4201: http://127.0.0.1:4201/
-.. _admin UI: https://crate.io/docs/crate/admin-ui/
+.. _admin UI: https://crate.io/docs/crate/admin-ui/en/latest/
 .. _Amazon EC2 API: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
 .. _Amazon EC2: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-on-amazon-ec2
 .. _Azure Virtual Machine API: https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines
@@ -471,7 +471,7 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 .. _bin/crate: https://crate.io/docs/crate/reference/en/latest/cli-tools.html#crate
 .. _cluster browser: https://crate.io/docs/crate/admin-ui/en/latest/cluster.html
 .. _cluster: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html
-.. _cluster.initial_master_nodes: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#cluster_initial_master_nodes
+.. _cluster.initial_master_nodes: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#cluster-initial-master-nodes
 .. _cluster.name: https://crate.io/docs/crate/reference/en/latest/config/node.html#cluster-name
 .. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _CRATE_HOME: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-crate-home
@@ -490,7 +490,7 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 .. _Microsoft Azure: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-on-microsoft-azure
 .. _More information about port settings: https://crate.io/docs/crate/reference/en/latest/config/node.html#ports
 .. _network.publish_host: https://crate.io/docs/crate/reference/en/latest/config/node.html#network-publish-host
-.. _node.master: https://crate.io/docs/crate/reference/en/latest/config/node.html#node.master
+.. _node.master: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-master
 .. _node.name: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-name
 .. _quorum guide: https://crate.io/docs/crate/howtos/en/latest/architecture/shared-nothing.html#master-node-election
 .. _quorum size: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html#master-node-election

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,6 @@
 from crate.theme.rtd.conf.crate_howtos import *
+
+linkcheck_ignore = [
+    # Forbidden by WordPress
+    "https://crate.io/wp-content/uploads/2018/11/copy_from_population_data.zip"
+]

--- a/docs/deployment/cloud/aws/ec2-setup.rst
+++ b/docs/deployment/cloud/aws/ec2-setup.rst
@@ -206,18 +206,18 @@ discovery by availability zone::
 
 See also `discovery.ec2.availability_zones`_.
 
-.. _1.2.0: https://crate.io/docs/crate/reference/release_notes/1.2.0.html
+.. _1.2.0: https://crate.io/docs/crate/reference/en/latest/appendices/release-notes/1.2.0.html
 .. _3.3: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery
-.. _Amazon EC2: http://aws.amazon.com/ec2
-.. _AWS CLI: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-cli
-.. _AWS Console: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-.. _AWS guide: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
-.. _discovery.ec2.availability_zones: https://crate.io/docs/crate/reference/configuration.html#discovery-on-amazon-ec2
-.. _discovery.ec2.groups: https://crate.io/docs/crate/reference/configuration.html#discovery-on-amazon-ec2
-.. _discovery.ec2.tags: https://crate.io/docs/crate/reference/configuration.html#discovery-on-amazon-ec2
-.. _EC2 API: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
-.. _Hosts: https://crate.io/docs/crate/reference/configuration.html#hosts
-.. _IAM roles: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+.. _Amazon EC2: https://aws.amazon.com/ec2/
+.. _AWS CLI: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-cli
+.. _AWS Console: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
+.. _AWS guide: httsp://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+.. _discovery.ec2.availability_zones: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-ec2-availability-zones
+.. _discovery.ec2.groups: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-ec2-groups
+.. _discovery.ec2.tags: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-ec2-tag-name
+.. _EC2 API: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
+.. _Hosts: https://crate.io/docs/crate/reference/en/latest/config/node.html#hosts
+.. _IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 .. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
-.. _sign the requests: http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-.. _Unicast Host Discovery: https://crate.io/docs/crate/reference/configuration.html#unicast-host-discovery
+.. _sign the requests: https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+.. _Unicast Host Discovery: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#unicast-host-discovery

--- a/docs/deployment/cloud/aws/s3-setup.rst
+++ b/docs/deployment/cloud/aws/s3-setup.rst
@@ -99,9 +99,9 @@ within the policy:
      ]
   }
 
-.. _`Amazon S3`: http://aws.amazon.com/s3
-.. _`sign the requests`: http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-.. _`IAM roles`: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
-.. _`AWS guide`: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
-.. _`AWS principals`: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Principal
-.. _`AWS policy examples`: http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html
+.. _`Amazon S3`: https://aws.amazon.com/s3/
+.. _`sign the requests`: https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+.. _`IAM roles`: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+.. _`AWS guide`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+.. _`AWS principals`: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+.. _`AWS policy examples`: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html

--- a/docs/deployment/cloud/azure.rst
+++ b/docs/deployment/cloud/azure.rst
@@ -7,8 +7,8 @@ Services in the world. It offers a wide variety of options including Windows
 servers, containers, application images and much more.
 
 Getting CrateDB working on Azure with Linux or Windows is a simple process. You
-can use Azure's management console or CLI interface (`Learn how to install here
-<https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-install/>`_).
+can use Azure's management console or CLI interface (`Learn how to install
+here`_).
 
 .. rubric:: Table of contents
 
@@ -93,7 +93,6 @@ To Install CrateDB, ssh into your VMs and follow `the standard process for
 Linux installation`_, this will automatically start an instance of CrateDB,
 which we will need to restart after the next step.
 
-.. _the standard process for Linux installation: https://crate.io/docs/crate/getting-started/en/latest/install/linux.html
 
 Configure CrateDB
 -----------------
@@ -126,9 +125,7 @@ Uncomment / add these lines:
 +-----------------+-----------+---------------------------------------+
 
 Note You might want to try DNS based discovery for inter-node communication,
-`find more details
-<https://crate.io/docs/reference/configuration.html#discovery-via-dns>`_ in our
-documentation.
+`find more details`_ in our documentation.
 
 Uncomment and set the cluster name
 
@@ -158,8 +155,7 @@ Install CrateDB
 
 *Note that these instructions should be followed on each VM in your cluster.*
 
-To install CrateDB on Windows Server, you will need a `Java JDK installed
-<http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_.
+To install CrateDB on Windows Server, you will need a `Java JDK installed`_.
 Ensure that the ``JAVA*HOME`` environment variable is set.
 
 .. image:: azure-envvar.png
@@ -168,7 +164,6 @@ Ensure that the ``JAVA*HOME`` environment variable is set.
 Next `download the CrateDB Tarball`_, expand it and move to a convenient
 location.
 
-.. _download the CrateDB Tarball: https://crate.io/docs/crate/getting-started/en/latest/install/local/tarball.html
 
 Configure CrateDB and Windows
 -----------------------------
@@ -185,5 +180,12 @@ We need to allow the ports CrateDB uses through the Windows Firewall
 
 Start crate by running ``bin/crate``.
 
-.. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
+
 .. _3.3: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery
+.. _download the CrateDB Tarball: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _find more details: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-via-dns
+.. _Java JDK installed: https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
+.. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
+.. _Learn how to install here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+.. _the standard process for Linux installation:  https://crate.io/docs/crate/tutorials/en/latest/install-run/linux.html
+

--- a/docs/deployment/containers/docker.rst
+++ b/docs/deployment/containers/docker.rst
@@ -493,21 +493,21 @@ example::
 .. _Bootstrap Checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
 .. _compose file version: https://docs.docker.com/compose/compose-file/compose-versioning/
 .. _containerization: https://www.docker.com/resources/what-container
-.. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/configuration.html#crate-heap-size
+.. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-heap-size
 .. _CrateDB Docker image: https://hub.docker.com/_/crate/
 .. _default bridge network: https://docs.docker.com/network/#network-drivers
-.. _Discovery: https://crate.io/docs/crate/reference/configuration.html#discovery
+.. _Discovery: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _Docker Stack YAML file: https://docs.docker.com/docker-cloud/apps/stack-yaml-reference/
 .. _Docker Swarm: https://docs.docker.com/engine/swarm/
 .. _Docker volume: https://docs.docker.com/engine/tutorials/dockervolumes/
 .. _Docker: https://www.docker.com/
 .. _going into production: https://crate.io/docs/crate/howtos/en/latest/going-into-production.html
 .. _healthcheck: https://docs.docker.com/engine/reference/builder/#healthcheck
-.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling
-.. _Metadata Gateway: https://crate.io/docs/crate/reference/configuration.html#metadata-gateway
-.. _running Docker locally: https://crate.io/docs/install/containers/docker/
-.. _set the maximum memory: https://docs.docker.com/engine/admin/resource_constraints/#memory
-.. _set the maximum number of CPUs: https://docs.docker.com/engine/admin/resource_constraints/#cpu
+.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_(scale_out)_and_vertical_scaling_(scale_up)
+.. _Metadata Gateway: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata-gateway
+.. _running Docker locally: https://crate.io/docs/crate/tutorials/en/latest/install-run/docker.html
+.. _set the maximum memory: https://docs.docker.com/config/containers/resource_constraints/#memory
+.. _set the maximum number of CPUs: https://docs.docker.com/config/containers/resource_constraints/#cpu
 .. _shared-nothing architecture : https://en.wikipedia.org/wiki/Shared-nothing_architecture
-.. _spinning up your first CrateDB instance: https://crate.io/docs/crate/getting-started/en/latest/install/containers/docker.html
-.. _user-defined network: https://docs.docker.com/engine/userguide/networking/#user-defined-networks
+.. _spinning up your first CrateDB instance: https://crate.io/docs/crate/tutorials/en/latest/install-run/docker.html
+.. _user-defined network: https://docs.docker.com/network/bridge/

--- a/docs/deployment/containers/kubernetes.rst
+++ b/docs/deployment/containers/kubernetes.rst
@@ -390,9 +390,9 @@ You can then use this in your controller configuration with something like this:
 .. _CrateDB Docker image: https://hub.docker.com/_/crate/
 .. _Docker: https://www.docker.com/
 .. _familiarity with Kubernetes: https://kubernetes.io/docs/tutorials/kubernetes-basics/
-.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_and_vertical_scaling
+.. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_(scale_out)_and_vertical_scaling_(scale_up)
 .. _Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/
-.. _kubeadm: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
+.. _kubeadm: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/
 .. _Kubernetes: https://kubernetes.io/
 .. _LoadBalancer: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
 .. _managed: https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/
@@ -400,7 +400,7 @@ You can then use this in your controller configuration with something like this:
 .. _node discovery via DNS: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-via-dns
 .. _persistent volume: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 .. _persistent volumes: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-.. _pod: https://kubernetes.io/docs/concepts/workloads/pods/pod/
+.. _pod: https://kubernetes.io/docs/concepts/workloads/pods/
 .. _rolling update strategy: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates
 .. _service: https://kubernetes.io/docs/concepts/services-networking/service/
 .. _services: https://kubernetes.io/docs/concepts/services-networking/service/

--- a/docs/deployment/linux/debian.rst
+++ b/docs/deployment/linux/debian.rst
@@ -26,8 +26,6 @@ the CrateDB Debian package.
    If you're just getting started with CrateDB, we also provide a `one-step
    Linux installer`_ .
 
-.. _one-step Linux installer: https://crate.io/docs/crate/getting-started/en/latest/install-run/special/linux.html
-
 .. rubric:: Table of contents
 
 .. contents::
@@ -39,8 +37,6 @@ Configure Apt
 
 Firstly, you will need to upgrade `Apt`_ (the Debian package manager) with HTTPS
 support, like so:
-
-.. _Apt: https://wiki.debian.org/Apt
 
 .. code-block:: sh
 
@@ -111,8 +107,6 @@ You should be able to access it by visiting::
 .. SEEALSO::
 
    If you're new to CrateDB, check out our our `first use`_ documentation.
-
-.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
 
 
 Controlling CrateDB
@@ -185,12 +179,14 @@ If you want to deviate from the way that the ``crate`` package integrates with
 your system, we recommend that you go with a `basic tarball installation`_.
 
 
-.. _basic tarball installation: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html
+.. _Apt: https://wiki.debian.org/Apt
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
 .. _Buster: https://www.debian.org/releases/buster/
 .. _configuration files: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _environment variables: https://crate.io/docs/crate/reference/en/latest/config/environment.html
+.. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
 .. _Jessie: https://www.debian.org/releases/jessie/
+.. _one-step Linux installer: https://crate.io/docs/crate/tutorials/en/latest/install-run/linux.html
 .. _sources: https://en.wikipedia.org/wiki/Source_(command)
 .. _Stretch: https://www.debian.org/releases/stretch/
 .. _Wheezy: https://www.debian.org/releases/wheezy/
-

--- a/docs/deployment/linux/red-hat.rst
+++ b/docs/deployment/linux/red-hat.rst
@@ -8,8 +8,6 @@ CrateDB maintains the official RPM repositories for:
 
 - `Red Hat Linux 7`_
 
-.. _Red Hat Linux 7: https://www.redhat.com/en/resources/whats-new-red-hat-enterprise-linux-7
-
 Both of these work with RedHat Enterprise Linux, CentOS, and Scientific Linux.
 
 .. rubric:: Table of contents
@@ -52,8 +50,6 @@ should select which one you wish to use.
 By default, `YUM`_ (Red Hat's package manager) will use the stable repository.
 This is because the testing repository's configuration marks it as disabled.
 
-.. _YUM: https://access.redhat.com/solutions/9934
-
 If you would like to enable to testing repository, open the ``crate.repo`` file
 and set ``enabled=1`` under the ``[crate-testing]`` section.
 
@@ -93,8 +89,6 @@ You should be able to access it by visiting::
 
    If you're new to CrateDB, check out our our `first use`_ documentation.
 
-.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
-
 .. CAUTION::
 
     Be sure to read the guide to :ref:`rolling upgrades <rolling_upgrade>` and
@@ -118,8 +112,6 @@ Environment
 
 The CrateDB startup script `sources`_ environment variables from the
 ``/etc/sysconfig/crate`` file.
-
-.. _sources: https://en.wikipedia.org/wiki/Source_(command)
 
 You can use this mechanism to configure CrateDB.
 
@@ -156,4 +148,8 @@ If you want to deviate from the way that the ``crate`` package integrates with
 your system, we recommend that you go with a `basic tarball installation`_.
 
 
-.. _basic tarball installation: https://crate.io/docs/crate/getting-started/en/latest/install-run/basic.html
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
+.. _Red Hat Linux 7: https://www.redhat.com/en/resources/whats-new-red-hat-enterprise-linux-7
+.. _sources: https://en.wikipedia.org/wiki/Source_(command)
+.. _YUM: https://access.redhat.com/solutions/9934

--- a/docs/deployment/linux/ubuntu.rst
+++ b/docs/deployment/linux/ubuntu.rst
@@ -172,10 +172,10 @@ your system, you can do a `basic tarball installation`_.
 
 
 .. _Apt: https://wiki.debian.org/Apt
-.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/getting-started/install-run/basic.html
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
 .. _configuration files: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _environment variables: https://crate.io/docs/crate/reference/en/latest/config/environment.html
-.. _first use: https://crate.io/docs/crate/getting-started/en/latest/first-use/index.html
+.. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
 .. _Java virtual machine: https://en.wikipedia.org/wiki/Java_virtual_machine
 .. _OpenJDK: https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa
 .. _release workflow: https://github.com/crate/crate/blob/master/devs/docs/release.rst

--- a/docs/going-into-production.rst
+++ b/docs/going-into-production.rst
@@ -418,7 +418,7 @@ send debug logs to `STDERR`_ so that the container orchestrator handles the
 output.
 
 
-.. _Admin UI: https://crate.io/docs/crate/admin-ui/
+.. _Admin UI: https://crate.io/docs/crate/admin-ui/en/latest/
 .. _bin/crate: https://crate.io/docs/crate/reference/en/latest/cli-tools.html#crate
 .. _cluster.name: https://crate.io/docs/crate/reference/en/latest/config/node.html#cluster-name
 .. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,4 +35,4 @@ massive amounts of machine data in real-time.
 
 
 .. _Tutorials: https://crate.io/docs/crate/tutorials/en/latest/
-.. _GitHub: https://github.com/crate/guide
+.. _GitHub: https://github.com/crate/crate-howtos

--- a/docs/integrations/azure-functions.rst
+++ b/docs/integrations/azure-functions.rst
@@ -352,12 +352,12 @@ can go through it step by step:
 	};
 
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text
-.. _Visual Studio Code: https://docs.microsoft.com/en-us/azure/azure-functions/functions-creathttps://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-locale-first-function-vs-code?pivots=programming-language-javascript
+.. _Visual Studio Code: https://code.visualstudio.com/
 .. _directly from VSCode: https://scotch.io/tutorials/getting-started-with-azure-functions-using-vs-code-zero-to-deploy
-.. _Azure CLI: https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function-azure-cli
+.. _Azure CLI: https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-csharp
 .. _node-postgres:  https://www.npmjs.com/package/pg
 .. _Azure Event Hubs bindings for Azure Functions documentation: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=javascript
-.. _CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
+.. _CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/cloud/azure.html
 .. _IoT Hub: https://azure.microsoft.com/en-us/services/iot-hub/
 .. _data simulators: https://docs.microsoft.com/en-us/azure/iot-accelerators/quickstart-device-simulation-deploy
 .. _development environment for Azure Functions: https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-local

--- a/docs/integrations/ml-dist.rst
+++ b/docs/integrations/ml-dist.rst
@@ -534,7 +534,7 @@ pipeline. The training and prediction stages are decoupled, and can be
 distributed across different machines, contexts, and scenarios.
 
 
-.. _A running CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
+.. _A running CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
 .. _An AWS S3 storage bucket: https://aws.amazon.com/s3/
 .. _boto3: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html
 .. _joblib: https://joblib.readthedocs.io/en/latest/index.html

--- a/docs/integrations/powerbi-desktop.rst
+++ b/docs/integrations/powerbi-desktop.rst
@@ -188,10 +188,9 @@ The pie chart will be updated automatically, and will produce the following:
 
 .. _business intelligence: https://en.wikipedia.org/wiki/Business_intelligence
 .. _World Economic Outlook survey: https://www.imf.org/en/Publications/WEO
-.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
+.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
 .. _Power BI Desktop: https://powerbi.microsoft.com/en-us/desktop/
 .. _PostgreSQL ODBC driver: https://odbc.postgresql.org/
 .. _downloads section: https://www.postgresql.org/ftp/odbc/versions/msi/
 .. _raw data: https://www.imf.org/external/pubs/ft/weo/2017/01/weodata/index.aspx
 .. _preprocessed archive: https://crate.io/wp-content/uploads/2018/11/copy_from_population_data.zip
-

--- a/docs/integrations/powerbi-gateway.rst
+++ b/docs/integrations/powerbi-gateway.rst
@@ -197,11 +197,11 @@ updated periodically.
 
 .. _Power BI service: https://powerbi.microsoft.com/en-us/
 .. _World Economic Outlook survey: https://www.imf.org/en/Publications/WEO
-.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
+.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
 .. _Power BI Desktop: https://powerbi.microsoft.com/en-us/desktop/
 .. _Microsoft Work/School account: https://support.microsoft.com/en-ca/help/4013943/sign-in-using-work-or-school-account
 .. _Power BI Pro/Trial account: https://app.powerbi.com/signupredirect?pbi_source=web
 .. _On-Premises Data Gateway: https://docs.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
 .. _install: https://docs.microsoft.com/en-us/data-integration/gateway/service-gateway-install
 .. _configure: https://docs.microsoft.com/en-us/data-integration/gateway/service-gateway-app
-.. _refresh the datasets: https://docs.microsoft.com/en-us/power-bi/refresh-data
+.. _refresh the datasets: https://docs.microsoft.com/en-us/power-bi/connect-data/refresh-data

--- a/docs/integrations/r.rst
+++ b/docs/integrations/r.rst
@@ -360,7 +360,7 @@ CrateDB.
 .. _R: https://www.r-project.org/
 .. _RPostgreSQL: https://cran.r-project.org/web/packages/RPostgreSQL/index.html
 .. _iris classification problem: https://en.wikipedia.org/wiki/Iris_flower_data_set
-.. _A running CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
+.. _A running CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
 .. _RStudio: https://rstudio.com/
 .. _caret: https://cran.r-project.org/web/packages/caret/index.html
 .. _Linear Discriminant Analysis: https://en.wikipedia.org/wiki/Linear_discriminant_analysis

--- a/docs/integrations/streamsets.rst
+++ b/docs/integrations/streamsets.rst
@@ -149,9 +149,9 @@ You can verify that the data is now in CrateDB:
     SELECT 1 row in set (0.050 sec)
 
 
-.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/tutorials/en/latest/getting-started/index.html
-.. _A running and accessable StreamSets Data Collector: https://streamsets.com/products/dataops-platform/data-collector/download/
-.. _Bintray Repository: https://bintray.com/crate/crate/crate-jdbc/view/files/io/crate/crate-jdbc-standalone/#files/io/crate/crate-jdbc-standalone/
+.. _A running and accessable CrateDB cluster: https://crate.io/docs/crate/howtos/en/latest/deployment/index.html
+.. _A running and accessable StreamSets Data Collector: https://streamsets.com/products/dataops-platform/data-collector/
+.. _Bintray Repository: https://bintray.com/crate/crate/crate-jdbc/view/files/io/crate/crate-jdbc-standalone/
 .. _CrateDB JDBC driver: https://crate.io/docs/jdbc/en/latest/
 .. _external libraries: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Configuration/ExternalLibs.html
 .. _New York taxi dataset: https://streamsets.com/documentation/datacollector/latest/help/datacollector/UserGuide/Tutorial/BeforeYouBegin.html?hl=nyc_taxi_data/

--- a/docs/performance/inserts/methods.rst
+++ b/docs/performance/inserts/methods.rst
@@ -279,6 +279,6 @@ throughput of your cluster with different setups and under different loads.
 .. _PostgreSQL wire protocol: https://crate.io/docs/crate/reference/en/latest/protocols/postgres.html
 .. _single inserts: https://crate.io/docs/crate/reference/sql/dml.html#inserting-data
 .. _SQL HTTP endpoint: https://crate.io/docs/crate/reference/protocols/http.html
-.. _the JDBC client: https://crate.io/docs/clients/jdbc/en/latest/
+.. _the JDBC client: https://crate.io/docs/jdbc/en/latest/
 .. _translog.durability: https://crate.io/docs/crate/reference/en/latest/sql/reference/create_table.html#translog-durability
 .. _UNNEST: https://crate.io/docs/crate/reference/en/latest/sql/table_functions.html#unnest-array-array

--- a/docs/performance/memory.rst
+++ b/docs/performance/memory.rst
@@ -112,10 +112,10 @@ like so:
 .. _Compressed Oops: https://wiki.openjdk.java.net/display/HotSpot/CompressedOops
 .. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _configurations: https://crate.io/docs/crate/reference/en/latest/config/index.html
-.. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#crate-heap-size
+.. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-heap-size
 .. _G1GC: https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm#JSGCT-GUID-0394E76A-1A8F-425E-A0D0-B48A3DC82B42
 .. _Garbage Collection: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
-.. _HotSpot Java Virtual Machine: http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136373.html
+.. _HotSpot Java Virtual Machine: https://www.oracle.com/java/technologies/javase/javase-core-technologies-apis.html
 .. _Lucene: https://lucene.apache.org/
 .. _Memory mapped files: https://en.wikipedia.org/wiki/Memory-mapped_file
 .. _x64 architectures: https://en.wikipedia.org/wiki/X86-64

--- a/docs/reference-architectures/distributed-ml.rst
+++ b/docs/reference-architectures/distributed-ml.rst
@@ -44,4 +44,4 @@ This architecture makes use of the following components and CrateDB integrations
 
 
 .. _Alertmanager: https://www.prometheus.io/docs/alerting/latest/alertmanager/
-.. _Prometheus: https://www.prometheus.io
+.. _Prometheus: https://prometheus.io/

--- a/docs/troubleshooting/docker-jcmd.rst
+++ b/docs/troubleshooting/docker-jcmd.rst
@@ -286,5 +286,5 @@ more possibilities to get diagnostic information using the ``jcmd`` command.
 You can find more information about the utility at the `jcmd documentation`_.
 
 
-.. _entrypoint: https://github.com/crate/docker-crate/blob/master/amd64/crate/docker-entrypoint.sh#L19-L22
+.. _entrypoint: https://github.com/crate/docker-crate/blob/master/docker-entrypoint.sh
 .. _jcmd documentation: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr006.html#BABEHABG


### PR DESCRIPTION
Additionally, drop notice about upgrading from 0.54 to 0.55. This notice links
to the blog, but WordPress returns a forbidden error. This link could be added
to `linkcheck_ignore` in `conf.py`. However, these versions are so old that we
do not even host the changelogs in the docs anymore.

---

for errors originally reported here: https://github.com/crate/tech-writing-domain/issues/336

