### PR TITLE
Correction: Define `POD_NAME` variable used in StatefulSet config

### DIFF
--- a/docs/deployment/containers/kubernetes.rst
+++ b/docs/deployment/containers/kubernetes.rst
@@ -291,6 +291,10 @@ CrateDB 3.0.5 cluster:
               value: "3"
             - name: CLUSTER_NAME
               value: "my-crate"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
fixes https://github.com/crate/crate-howtos/issues/264

## Summary of the changes / Why this is an improvement

The StatefulSet configuration tries to set `node.name` using a variable named
`POD_NAME`. However, no such variable is defined. This change defines
`POD_NAME` as a variable that gets its value from the `metadata.name` field.
