### PR TITLE
Update to crate-docs 2.0.0 and fix broken links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -79,8 +79,8 @@ BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs.git
 LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
 CLONE_DIR     := .crate-docs
-SRC_DIR       := $(CLONE_DIR)/src
-SELF_SRC      := $(TOP_DIR)/src
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
@@ -100,7 +100,7 @@ LATEST_VERSION := $(shell curl -sI --connect-timeout 2 '$(LATEST_BUILD)' | \
 # Skip if no version could be determined (i.e., because of a network error)
 ifneq ($(LATEST_VERSION),)
 # Only issue a warning if there is a version mismatch
-ifeq ($(BUILD_VERSION),$(LATEST_VERSION))
+ifneq ($(BUILD_VERSION),$(LATEST_VERSION))
 define version_warning
 You are using Crate Docs version $(BUILD_VERSION), however version \
 $(LATEST_VERSION) is available. You should consider upgrading. Follow the \

--- a/docs/admin/bootstrap-checks.rst
+++ b/docs/admin/bootstrap-checks.rst
@@ -115,9 +115,9 @@ Garbage collection
 ==================
 
 CrateDB has been tested using the `CMS garbage collector`_ (default up to and
-including CrateDB 4.0) and `G1GC`_ (the default with CrateDB 4.1).
+including CrateDB 4.0) and the `G1 garbage collector`_ (the default with CrateDB 4.1).
 
-`G1GC` can also be used in earlier CrateDB versions, but should only be used in
+``G1GC`` can also be used in earlier CrateDB versions, but should only be used in
 combination with Java 11 or later.
 
 .. WARNING::
@@ -127,4 +127,4 @@ combination with Java 11 or later.
 
 
 .. _CMS garbage collector: https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html
-.. _G1GC: https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm
+.. _G1 garbage collector: https://docs.oracle.com/javase/10/gctuning/garbage-first-garbage-collector.htm

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "1.0.0"
+  "message": "2.0.0"
 }

--- a/docs/clustering/multi-node-setup.rst
+++ b/docs/clustering/multi-node-setup.rst
@@ -499,7 +499,7 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 .. _split-brain: https://en.wikipedia.org/wiki/Split-brain_(computing)
 .. _SRV records: https://en.wikipedia.org/wiki/SRV_record
 .. _sys.summits: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#summits
-.. _tarball method: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _tarball method: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _transport.publish_port: https://crate.io/docs/crate/reference/en/latest/config/node.html#transport-publish-port
 .. _transport.tcp.port: https://crate.io/docs/crate/reference/en/latest/config/node.html#transport-tcp-port
 .. _unicast hosts: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#unicast-host-discovery

--- a/docs/deployment/cloud/azure.rst
+++ b/docs/deployment/cloud/azure.rst
@@ -182,10 +182,9 @@ Start crate by running ``bin/crate``.
 
 
 .. _3.3: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery
-.. _download the CrateDB Tarball: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _download the CrateDB Tarball: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _find more details: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery-via-dns
 .. _Java JDK installed: https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html
 .. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _Learn how to install here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
-.. _the standard process for Linux installation:  https://crate.io/docs/crate/tutorials/en/latest/install-run/linux.html
-
+.. _the standard process for Linux installation: https://crate.io/docs/crate/tutorials/en/latest/install.html

--- a/docs/deployment/containers/docker.rst
+++ b/docs/deployment/containers/docker.rst
@@ -505,9 +505,9 @@ example::
 .. _healthcheck: https://docs.docker.com/engine/reference/builder/#healthcheck
 .. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_(scale_out)_and_vertical_scaling_(scale_up)
 .. _Metadata Gateway: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata-gateway
-.. _running Docker locally: https://crate.io/docs/crate/tutorials/en/latest/install-run/docker.html
+.. _running Docker locally: https://crate.io/docs/crate/tutorials/en/latest/install.html#docker
 .. _set the maximum memory: https://docs.docker.com/config/containers/resource_constraints/#memory
 .. _set the maximum number of CPUs: https://docs.docker.com/config/containers/resource_constraints/#cpu
 .. _shared-nothing architecture : https://en.wikipedia.org/wiki/Shared-nothing_architecture
-.. _spinning up your first CrateDB instance: https://crate.io/docs/crate/tutorials/en/latest/install-run/docker.html
+.. _spinning up your first CrateDB instance: https://crate.io/docs/crate/tutorials/en/latest/install.html#docker
 .. _user-defined network: https://docs.docker.com/network/bridge/

--- a/docs/deployment/linux/debian.rst
+++ b/docs/deployment/linux/debian.rst
@@ -180,13 +180,13 @@ your system, we recommend that you go with a `basic tarball installation`_.
 
 
 .. _Apt: https://wiki.debian.org/Apt
-.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _Buster: https://www.debian.org/releases/buster/
 .. _configuration files: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _environment variables: https://crate.io/docs/crate/reference/en/latest/config/environment.html
 .. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
 .. _Jessie: https://www.debian.org/releases/jessie/
-.. _one-step Linux installer: https://crate.io/docs/crate/tutorials/en/latest/install-run/linux.html
+.. _one-step Linux installer: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _sources: https://en.wikipedia.org/wiki/Source_(command)
 .. _Stretch: https://www.debian.org/releases/stretch/
 .. _Wheezy: https://www.debian.org/releases/wheezy/

--- a/docs/deployment/linux/red-hat.rst
+++ b/docs/deployment/linux/red-hat.rst
@@ -148,7 +148,7 @@ If you want to deviate from the way that the ``crate`` package integrates with
 your system, we recommend that you go with a `basic tarball installation`_.
 
 
-.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html
 .. _Red Hat Linux 7: https://www.redhat.com/en/resources/whats-new-red-hat-enterprise-linux-7
 .. _sources: https://en.wikipedia.org/wiki/Source_(command)

--- a/docs/deployment/linux/ubuntu.rst
+++ b/docs/deployment/linux/ubuntu.rst
@@ -172,7 +172,7 @@ your system, you can do a `basic tarball installation`_.
 
 
 .. _Apt: https://wiki.debian.org/Apt
-.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install-run/basic.html
+.. _basic tarball installation: https://crate.io/docs/crate/tutorials/en/latest/install.html#ad-hoc-installation-unix-windows
 .. _configuration files: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _environment variables: https://crate.io/docs/crate/reference/en/latest/config/environment.html
 .. _first use: https://crate.io/docs/crate/tutorials/en/latest/first-use.html

--- a/docs/performance/inserts/bulk.rst
+++ b/docs/performance/inserts/bulk.rst
@@ -414,10 +414,10 @@ For exmaple::
 .. _COPY FROM: https://crate.io/docs/crate/reference/en/latest/sql/reference/copy_from.html
 .. _CrateDB Reference\: Alter a partitioned table: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html#alter
 .. _CrateDB Reference\: Import and export: https://crate.io/docs/crate/reference/en/latest/general/dml.html#import-and-export
-.. _CrateDB Reference\: PARTITIONED BY: https://crate.io/docs/crate/reference/en/latest/sql/reference/create_table.html#partitioned-by-clause
+.. _CrateDB Reference\: PARTITIONED BY: https://crate.io/docs/crate/reference/en/latest/sql/statements/create-table.html#partitioned-by
 .. _CrateDB Reference\: Partitioned tables: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html
-.. _distributed database: https://crate.io/docs/crate/reference/en/4.4/concepts/shared-nothing.html
-.. _drop: https://crate.io/docs/crate/reference/en/4.4/sql/statements/drop-table.html?highlight=drop
+.. _distributed database: https://crate.io/docs/crate/reference/en/latest/concepts/clustering.html
+.. _drop: https://crate.io/docs/crate/reference/en/4.4/sql/statements/drop-table.html
 .. _gzip: https://www.gnu.org/software/gzip/
 .. _IOPS: https://en.wikipedia.org/wiki/IOPS
 .. _JSON lines: https://jsonlines.org/

--- a/docs/performance/memory.rst
+++ b/docs/performance/memory.rst
@@ -89,7 +89,7 @@ offset the memory lost due to the lack of *Compressed Oops*.
 
 .. TIP::
 
-    When configuring heap size via `CRATE_HEAP_SIZE`_, you can specify 30.5
+    When configuring the heap size via `CRATE_HEAP_SIZE`_, you can specify 30.5
     gigabytes with the value ``30500m``.
 
 
@@ -113,7 +113,7 @@ like so:
 .. _configuration: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _configurations: https://crate.io/docs/crate/reference/en/latest/config/index.html
 .. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-heap-size
-.. _G1GC: https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm#JSGCT-GUID-0394E76A-1A8F-425E-A0D0-B48A3DC82B42
+.. _G1GC: https://docs.oracle.com/javase/10/gctuning/garbage-first-garbage-collector.htm
 .. _Garbage Collection: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
 .. _HotSpot Java Virtual Machine: https://www.oracle.com/java/technologies/javase/javase-core-technologies-apis.html
 .. _Lucene: https://lucene.apache.org/

--- a/docs/performance/selects.rst
+++ b/docs/performance/selects.rst
@@ -109,4 +109,4 @@ to the original result.
 .. _Lucene segment: https://stackoverflow.com/a/2705123
 .. _modulo (%) operation: https://crate.io/docs/crate/reference/en/latest/general/builtins/arithmetic.html
 .. _normal distribution: https://en.wikipedia.org/wiki/Normal_distribution
-.. _sub-selects: https://crate.io/docs/crate/reference/en/latest/sql/statements/select.html#sub-select
+.. _sub-selects: https://crate.io/docs/crate/reference/en/latest/sql/statements/select.html#subselect


### PR DESCRIPTION
Hi there,

this patch is needed in order to be able to continue working on the content. Otherwise, the link checker will fail badly.

With kind regards,
Andreas.
