### PR TITLE
Update Kafka Connect guide to make use of the new JSON data type

### DIFF
--- a/docs/clustering/kubernetes.rst
+++ b/docs/clustering/kubernetes.rst
@@ -178,8 +178,8 @@ Recovery behavior
 CrateDB has two settings that depend on cluster size and determine how cluster
 `metadata`_ is recovered during startup:
 
-- `gateway.expected_nodes`_
-- `gateway.recover_after_nodes`_
+- `gateway.expected_data_nodes`_
+- `gateway.recover_after_data_nodes`_
 
 The values of these settings must be changed via Kubernetes. Unlike with
 clustering behavior reconfiguration, you cannot change these values using
@@ -188,7 +188,7 @@ CrateDB's `runtime configuration`_ capabilities.
 If you are using a controller configuration like the example given in the
 :ref:`Kubernetes deployment guide <cratedb-kubernetes>`, you can make this
 reconfiguration by altering the ``EXPECTED_NODES`` environment variable and the
-``recover_after_nodes`` command option.
+``recover_after_data_nodes`` command option.
 
 Changes to the Kubernetes controller configuration can then be deployed using
 ``kubectl replace`` as shown in the previous subsection, `Using Version
@@ -210,8 +210,8 @@ Control`_.
 .. _deleted and recreated: https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#disruptive-updates
 .. _discovery.zen.minimum_master_nodes: https://crate.io/docs/crate/reference/en/3.3/config/cluster.html#discovery-zen-minimum-master-nodes
 .. _Docker: https://www.docker.com/
-.. _gateway.expected_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-expected-nodes
-.. _gateway.recover_after_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-after-nodes
+.. _gateway.expected_data_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-expected-data-nodes
+.. _gateway.recover_after_data_nodes: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#recovery-after-data-nodes
 .. _horizontally scalable: https://en.wikipedia.org/wiki/Scalability#Horizontal_(scale_out)_and_vertical_scaling_(scale_up)
 .. _imperative command: https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/#imperative-commands
 .. _kubectl: https://kubernetes.io/docs/reference/kubectl/overview/

--- a/docs/integrations/azure-functions.rst
+++ b/docs/integrations/azure-functions.rst
@@ -369,7 +369,7 @@ a new device and send a device-to-cloud (D2C) message for testing purposes.
 
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text
 .. _Visual Studio Code: https://code.visualstudio.com/
-.. _directly from VSCode: https://scotch.io/tutorials/getting-started-with-azure-functions-using-vs-code-zero-to-deploy
+.. _directly from VSCode: https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs-code
 .. _Azure CLI: https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-csharp
 .. _node-postgres:  https://www.npmjs.com/package/pg
 .. _Azure Event Hubs bindings for Azure Functions documentation: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=javascript

--- a/docs/integrations/kafka-connect.rst
+++ b/docs/integrations/kafka-connect.rst
@@ -6,16 +6,15 @@ This integration document details how to create an ingestion
 pipeline from a `Kafka`_ source to a CrateDB sink, using the `Kafka Connect
 JDBC connector`_.
 
-
 Abstract
 ========
 
 Kafka is a popular stream processing software used for building scalable data
 processing pipelines and applications. Many different use-cases might involve
-wanting to ingest the data from a Kafka topic (or several topics) into a
-CrateDB for further enrichment, analysis or visualization. This can be done
-using the supplementary component `Kafka Connect`_, which provides a set of
-connectors that can stream data to and from Kafka.
+wanting to ingest the data from a Kafka topic (or several topics) into CrateDB
+for further enrichment, analysis, or visualization. This can be done using the
+supplementary component `Kafka Connect`_, which provides a set of connectors
+that can stream data to and from Kafka.
 
 Using the `Kafka Connect JDBC connector`_ with the PostgreSQL driver allows
 you to designate CrateDB as a sink target, with the following example connector
@@ -23,17 +22,17 @@ definition:
 
 .. code-block:: json
 
-   {
-     "name": "cratedb-connector",
-     "config": {
-       "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
-       "topics": "metrics",
-       "connection.url": "jdbc:postgresql://localhost:5432/doc?user=crate",
-       "tasks.max": 1,
-       "insert.mode": "insert",
-       "table.name.format": "metrics",
-     }
+  {
+   "name": "cratedb-connector",
+   "config": {
+     "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+     "topics": "metrics",
+     "connection.url": "jdbc:postgresql://localhost:5432/doc?user=crate",
+     "tasks.max": 1,
+     "insert.mode": "insert",
+     "table.name.format": "metrics"
    }
+  }
 
 This results in the following architecture:
 
@@ -85,10 +84,10 @@ The fields in the payload are:
 Prerequisites
 -------------
 
-In order to deploy this architecture, there are several prerequisites:
+To deploy this architecture, there are several prerequisites:
 
 - A running and accessible Kafka stack, including Kafka, ZooKeeper, Schema
-  Registry and Kafka Connect. This example implementation will use the
+  Registry, and Kafka Connect. This example implementation will use the
   `Confluent Platform`_ to start and interact with the components, but there are
   many different avenues and libraries available.
 - A CrateDB Cluster, running on at least version 4.2.0.
@@ -106,8 +105,8 @@ development stack can be done via:
 
    $ confluent local services start
 
-   Starting zookeeper
-   zookeeper is [UP]
+   Starting ZooKeeper
+   ZooKeeper is [UP]
    Starting Kafka
    Kafka is [UP]
    Starting Schema Registry
@@ -117,8 +116,8 @@ development stack can be done via:
    Starting Connect
    Connect is [UP]
 
-Next, you should define the `Avro schema`_ that your producers, in this case
-weather sensors, will produce. Given the structure described in the setup
+Next, you should define the `Avro schema`_ of the producer's messages, in this
+case, weather sensors. Given the structure described in the setup
 section, the Avro schema will be:
 
 .. code-block:: json
@@ -145,18 +144,19 @@ section, the Avro schema will be:
    }
 
 
-For the purposes of this example, this Python script will simulate the creation
+For this example, this Python script will simulate the creation
 of random sensor data and push it into the ``metrics`` topic:
 
 .. code-block:: python
 
-   from confluent_kafka import avro
-   from confluent_kafka.avro import AvroProducer
    import time
    import random
 
+   from confluent_kafka import avro
+   from confluent_kafka.avro import AvroProducer
+
    # Define the Avro schema we want our produced records to conform to.
-   value_schema_str = """
+   VALUE_SCHEMA_STR = """
    {
      "namespace": "cratedb.metrics",
      "name": "value",
@@ -180,52 +180,43 @@ of random sensor data and push it into the ``metrics`` topic:
    """
 
    # Load the Avro schema.
-   value_schema = avro.loads(value_schema_str)
+   VALUE_SCHEMA = avro.loads(VALUE_SCHEMA_STR)
 
    # Create an Avro producer using the defined schema, assuming that our
    # Kafka servers are running at localhost:9092 and the Schema Registry
    # server is running at localhost:8081.
-   avroProducer = AvroProducer(
+   AVRO_PRODUCER = AvroProducer(
        {
            "bootstrap.servers": "localhost:9092",
            "schema.registry.url": "http://localhost:8081",
        },
-       default_value_schema=value_schema,
+       default_value_schema=VALUE_SCHEMA,
    )
 
    # Create a metric payload from a simulated sensor device.
    def create_metric():
-       sensor_id = "sensor-" + str(random.choice(list(range(1, 21))))
-       temperature = random.uniform(-5, 35)
-       humidity = random.uniform(0, 100)
-       pressure = random.uniform(1000, 1030)
-       luminosity = random.uniform(0, 65000)
-       timestamp = int(time.time())
        return {
-           "id": sensor_id,
-           "timestamp": timestamp,
+           "id": "sensor-" + str(random.choice(list(range(1, 21)))),
+           "timestamp": int(time.time()),
            "payload": {
-               "temperature": temperature,
-               "humidity": humidity,
-               "pressure": pressure,
-               "luminosity": luminosity,
-               "timestamp": timestamp,
+               "temperature": random.uniform(-5, 35),
+               "humidity": random.uniform(0, 100),
+               "pressure": random.uniform(1000, 1030),
+               "luminosity": random.uniform(0, 65000),
            },
        }
 
-
    # Create a new metric every 0.25 seconds and push it to the metrics topic.
    while True:
-       value = create_metric()
-       avroProducer.produce(topic="metrics", value=value)
-       avroProducer.flush()
+       AVRO_PRODUCER.produce(topic="metrics", value=create_metric())
+       AVRO_PRODUCER.flush()
        time.sleep(0.25)
 
 This script can be run by installing the following dependencies and running it:
 
 .. code-block:: console
 
-   $ pip install "confluent-kafka[avro]" "requests" "avro-python3"
+   $ pip install "confluent-kafka[avro]" "avro-python3"
    $ python simulator.py
 
 You can verify that the simulator is working by consuming from the Kafka topic:
@@ -239,135 +230,143 @@ You can verify that the simulator is working by consuming from the Kafka topic:
    {"id":"sensor-20","timestamp":1.59180096E9,"payload":{"temperature":5.555978,"humidity":34.635147,"pressure":1028.5662,"luminosity":16234.626}}
    {"id":"sensor-7","timestamp":1.59180096E9,"payload":{"temperature":12.604255,"humidity":70.70301,"pressure":1009.50116,"luminosity":37786.098}}
 
-
-CrateDB
--------
-
-The `PostgreSQL Kafka Connect JDBC driver`_ does not support nested structures
-such as our payload object. The nested record will have to be flattened to
-be ingested. You can do this using ``_`` as a delimiter, so that the
-``payload.temperature`` field will be ingested into the ``payload_temperature``
-column. Your CrateDB table's structure will, therefore, look like this:
-
-.. code-block:: sql
-
-  CREATE TABLE IF NOT EXISTS "doc"."metrics" (
-    "timestamp" TIMESTAMP WITH TIME ZONE,
-    "payload_temperature" REAL,
-    "payload_humidity" REAL,
-    "payload_pressure" REAL,
-    "payload_luminosity" REAL,
-    "id" TEXT
-   );
-
-
 Kafka Connect
--------------
+=============
 
 Before you initialise the JDBC connector to ingest data into CrateDB, you should
-first verify that the JDBC connector plugin is available on your Kafka Connect
+verify that the JDBC connector plugin is available on your Kafka Connect
 instance.
 
-You can do this by using the confluent command line tool, to list all available
+You can do this by using the confluent command-line tool, to list all available
 Connect plugins:
 
 .. code-block:: console
 
-   $ confluent local services connect plugin list
-    Available Connect Plugins:
-    [
-       ...
-       {
-           "class": "io.confluent.connect.jdbc.JdbcSinkConnector",
-           "type": "sink",
-           "version": "5.5.0"
-       },
-       {
-           "class": "io.confluent.connect.jdbc.JdbcSourceConnector",
-           "type": "source",
-           "version": "5.5.0"
-       },
-       ...
-   ]
+  $ confluent local services connect plugin list
+   Available Connect Plugins:
+   [
+      ...
+      {
+          "class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+          "type": "sink",
+          "version": "10.1.1"
+      },
+      ...
+  ]
 
-Two of the connector plugins listed should be of the class
-``io.confluent.connect.jdbc``, one of which is the `Sink Connector`_ and one of
-which is the `Source Connector`_. You will be using the Sink Connector, as we
-want CrateDB to act as a sink for Kafka records, rather than a source of Kafka
-records.
+We will be using the ``io.confluent.connect.jdbc.JdbcSinkConnector`` connector.
+In addition to that, another plugin is needed for transforming the message into
+JSON format. This can be installed via:
 
-Now, you can define the connector you want to initialize. The connector
-definition for this use case would look like this, which you should save to a
-file called ``cratedb_connector.json``:
+.. code-block:: console
+
+  $ confluent-hub install jcustenborder/kafka-connect-transform-common:latest
+
+CrateDB
+-------
+.. CAUTION::
+
+   The steps below apply to CrateDB versions >= 4.7.0.
+   For older versions, please see :ref:`Older CrateDB versions <kafka-connect-older-CrateDB-versions>`.
+
+We start by creating the target table. The columns ``topic``, ``partition``, and
+``offset`` will be filled by Kafka with their corresponding values.
+The message is modelled as an ``OBJECT(DYNAMIC)``, meaning it will
+automatically add and index new fields from your record.
+
+.. code-block:: sql
+
+  CREATE TABLE "doc"."metrics" (
+      "topic" TEXT NOT NULL,
+      "partition" INTEGER NOT NULL,
+      "offset" BIGINT NOT NULL,
+      "message" OBJECT(DYNAMIC) AS (
+          "id" TEXT,
+          "timestamp" TIMESTAMP,
+          "payload" OBJECT(DYNAMIC) AS (
+              "humidity" REAL,
+              "luminosity" REAL,
+              "pressure" REAL,
+              "temperature" REAL
+          )
+      ),
+      PRIMARY KEY ("topic", "partition", "offset")
+  );
+
+Now we can define the JDBC sink connector. The connector
+definition for this use case looks like this, which you should save to a file
+called ``cratedb_connector.json``:
 
 .. code-block:: json
 
-   {
-     "name": "cratedb-connector",
-     "config": {
-       "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
-       "topics": "metrics",
-       "connection.url": "jdbc:postgresql://localhost:5432/doc?user=crate",
-       "tasks.max": 3,
-       "insert.mode": "insert",
-       "table.name.format": "metrics",
-       "transforms.flatten.type": "org.apache.kafka.connect.transforms.Flatten$Value",
-       "transforms": "flatten",
-       "transforms.flatten.delimiter": "_"
-     }
-   }
+  {
+    "name": "cratedb-connector",
+    "config": {
+      "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+      "connection.url": "jdbc:postgresql://localhost:5432/doc?user=crate",
+      "topics": "metrics",
+      "tasks.max": 1,
+      "insert.mode": "insert",
+      "table.name.format": "metrics",
 
-Here are the parameters in more detail:
+      "pk.mode": "kafka",
+      "pk.fields": "topic,partition,offset",
 
-+----------------------------------+--------------------------------------------------------------------------+
-| Parameter                        | Description                                                              |
-+==================================+==========================================================================+
-| ``connector.class``              | The type of Connector plugin that you want to                            |
-|                                  | initialize.                                                              |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``connection.url``               | The URL to the CrateDB instance that you want                            |
-|                                  | to act as the sink. This should be in the form                           |
-|                                  | ``jdbc://postgresql://<CrateDB Host>:<PSQL Port>/<Schema>?user=<User>``. |
-|                                  | In this implementation, the CrateDB is running                           |
-|                                  | at ``localhost``, using the default PSQL port                            |
-|                                  | of ``5432``, the schema ``doc`` and the default                          |
-|                                  | CrateDB user ``crate``.                                                  |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``topics``                       | The list of topics we want the connector to                              |
-|                                  | consume from. In this implementation it is                               |
-|                                  | only the ``metrics`` topic, but it could be                              |
-|                                  | several.                                                                 |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``tasks.max``                    | The max number of Connector tasks that should be                         |
-|                                  | created to consume from this topic. Having a                             |
-|                                  | number higher than 1 allows you to parallelize                           |
-|                                  | consumption, to have higher throughput.                                  |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``insert.mode``                  | How the data consumed from the topics should                             |
-|                                  | be inserted into CrateDB. In this implementation                         |
-|                                  | ``insert`` is chosen, as no primary key exists for                       |
-|                                  | each record. If a primary key did exist, you could                       |
-|                                  | use ``upsert`` to update records in the table if                         |
-|                                  | they already exist for that primary key.                                 |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``table.name.format``            | The table that the data should be used to ingest                         |
-|                                  | the data. Although statically set here, you could                        |
-|                                  | use the ``${topic}`` parameter to dynamically                            |
-|                                  | insert into tables based on the topic name.                              |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``transforms``                   | The `Kafka Connect Transformation`_ to use while                         |
-|                                  | ingesting this data. In this case ``flatten``, since                     |
-|                                  | the nested payload must be flattened so that the                         |
-|                                  | PostgreSQL JDBC Connector can ingest it.                                 |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``transforms.flatten.type``      | The type of `Flatten Transformation`_ to use.                            |
-+----------------------------------+--------------------------------------------------------------------------+
-| ``transforms.flatten.delimiter`` | Which delimiter to use to separate field names                           |
-|                                  | when flattening nested structures.                                       |
-+----------------------------------+--------------------------------------------------------------------------+
+      "transforms": "toJSON,wrapValue",
+      "transforms.toJSON.type": "com.github.jcustenborder.kafka.connect.transform.common.ToJSON$Value",
+      "transforms.toJSON.schemas.enable": false,
+      "transforms.wrapValue.type": "org.apache.kafka.connect.transforms.HoistField$Value",
+      "transforms.wrapValue.field": "message"
+    }
+  }
 
-Many more `general Connector settings`_ as well as specific `JDBC Connector
-settings`_ exist which can affect things like batch inserting, parallelization,
+Here is more detail for some of the parameters:
+
++--------------------------------------+--------------------------------------------------------------------------+
+| Parameter                            | Description                                                              |
++======================================+==========================================================================+
+| ``connector.class``                  | The type of Connector plugin that you want to                            |
+|                                      | initialize.                                                              |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``connection.url``                   | The URL to the CrateDB instance that you want                            |
+|                                      | to act as the sink. This should be in the form                           |
+|                                      | ``jdbc://postgresql://<CrateDB Host>/<Schema>?user=<User>``.             |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``topics``                           | The list of topics we want the connector to                              |
+|                                      | consume from. In this implementation, it is                              |
+|                                      | only the ``metrics`` topic, but it could be                              |
+|                                      | several.                                                                 |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``tasks.max``                        | The max number of connector tasks that should be                         |
+|                                      | created to consume messages. Having a                                    |
+|                                      | number higher than 1 allows you to parallelize                           |
+|                                      | consumption, to have higher throughput.                                  |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``insert.mode``                      | How the data consumed from the topics should                             |
+|                                      | be inserted into CrateDB. We choose ``insert`` is chosen, as messages    |
+|                                      | do not get updated after initial publishing.                             |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``table.name.format``                | The target table name. ``${topic}`` can be used as a dynamic part of     |
+|                                      | the name.                                                                |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``pk.mode``                          | Lets Kafka determine the primary key based on its metadata.              |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``pk.fields``                        | A list of attributes uniquely describing a message.                      |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``transforms``                       | A list of transformation rules to apply, which are defined further down. |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``transforms.toJSON.type``           | Specified the class providing the transformation and sets the record's   |
+|                                      | value as the transformation target.                                      |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``transforms.toJSON.schemas.enable`` | Disables the schema of the JSON getting included.                        |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``transforms.wrapValue.type``        | Wraps the generated JSON into a field. The field equals the column in    |
+|                                      | our target table.                                                        |
++--------------------------------------+--------------------------------------------------------------------------+
+| ``transforms.wrapValue.field``       | The name of the field containing the serialized JSON.                    |
++--------------------------------------+--------------------------------------------------------------------------+
+
+More `JDBC Sink Connector settings`_ exist which can affect things like batch inserting, parallelization,
 etc.
 
 You can now create a connector instance using this configuration:
@@ -385,17 +384,21 @@ You can now create a connector instance using this configuration:
        "tasks.max": "1",
        "insert.mode": "insert",
        "table.name.format": "metrics",
-       "transforms.flatten.type": "org.apache.kafka.connect.transforms.Flatten$Value",
-       "transforms": "flatten",
-       "transforms.flatten.delimiter": "_",
+       "pk.mode": "kafka",
+       "pk.fields": "topic,partition,offset",
+       "transforms": "toJSON,wrapValue",
+       "transforms.toJSON.type": "com.github.jcustenborder.kafka.connect.transform.common.ToJSON$Value",
+       "transforms.toJSON.schemas.enable": "false",
+       "transforms.wrapValue.type": "org.apache.kafka.connect.transforms.HoistField$Value",
+       "transforms.wrapValue.field": "message",
        "name": "cratedb-connector"
      },
      "tasks": [],
      "type": "sink"
    }
 
-You can monitor the status of the newly created connector and verify that it
-is running:
+You can monitor the status of the newly created connector and verify that it is
+running:
 
 .. code-block:: console
 
@@ -421,34 +424,79 @@ Finally, you can verify that data is flowing into the CrateDB table:
 
 .. code-block:: console
 
-   cr> SELECT count(*) FROM metrics;
+   $ crash
+   cr> SELECT COUNT(*) FROM metrics;
    +----------+
    | count(*) |
    +----------+
    |     3410 |
    +----------+
 
-   cr> SELECT * from metrics limit 5;
-   +---------------+---------------------+------------------+------------------+--------------------+-----------+
-   |     timestamp | payload_temperature | payload_humidity | payload_pressure | payload_luminosity | id        |
-   +---------------+---------------------+------------------+------------------+--------------------+-----------+
-   | 1591799971840 |          17.4522    |        33.82939  |       1012.5672  |          4301.833  | sensor-48 |
-   | 1591799971840 |          -3.0050468 |        61.810287 |       1016.3813  |         60734.027  | sensor-23 |
-   | 1591799971840 |           3.0375347 |        17.890663 |       1017.25525 |         10318.256  | sensor-26 |
-   | 1591799971840 |          12.111576  |        70.71402  |       1003.64294 |          1785.4082 | sensor-2  |
-   | 1591799971840 |          -0.5194106 |        17.87835  |       1022.2261  |         15849.575  | sensor-8  |
-   +---------------+---------------------+------------------+------------------+--------------------+-----------+
+   cr> SELECT * FROM metrics LIMIT 5;
+   +---------+-----------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | topic   | partition | offset | message                                                                                                                                                       |
+   +---------+-----------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | metrics |         0 |  24521 | {"id": "sensor-16", "payload": {"humidity": 95.754425, "luminosity": 63707.867, "pressure": 1029.3485, "temperature": 27.77532}, "timestamp": 1627477760.0}   |
+   | metrics |         0 |  24523 | {"id": "sensor-18", "payload": {"humidity": 8.981689, "luminosity": 33933.863, "pressure": 1025.1156, "temperature": 27.980207}, "timestamp": 1627477760.0}   |
+   | metrics |         0 |  24525 | {"id": "sensor-20", "payload": {"humidity": 36.30519, "luminosity": 36909.668, "pressure": 1028.3536, "temperature": 16.281057}, "timestamp": 1627477760.0}   |
+   | metrics |         0 |  24533 | {"id": "sensor-13", "payload": {"humidity": 80.966446, "luminosity": 38612.555, "pressure": 1023.91144, "temperature": 13.155711}, "timestamp": 1627477760.0} |
+   | metrics |         0 |  24538 | {"id": "sensor-4", "payload": {"humidity": 43.69954, "luminosity": 29412.008, "pressure": 1003.7084, "temperature": 8.321792}, "timestamp": 1627477760.0}     |
+   +---------+-----------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. _kafka-connect-older-CrateDB-versions:
+
+Older CrateDB versions
+^^^^^^^^^^^^^^^^^^^^^^
+
+CrateDB versions older than 4.7.0 don't support the ``JSON`` data type yet,
+which requires a slightly different setup. Instead of storing messages as an
+``OBJECT``, they need to be flattened and modelled as separate columns.
+
+Please follow the steps above with two variations.
+
+**Target table layout:** Use this ``CREATE TABLE`` statement with a flattened
+column layout.
+
+.. code-block:: sql
+
+    CREATE TABLE "doc"."metrics" (
+      "timestamp" TIMESTAMP WITH TIME ZONE,
+      "payload_temperature" REAL,
+      "payload_humidity" REAL,
+      "payload_pressure" REAL,
+      "payload_luminosity" REAL,
+      "id" TEXT
+    );
+
+**JDBC Sink Connector configuration:** Use this connector configuration to
+flatten nested fields.
+
+.. code-block:: json
+
+  {
+    "name": "cratedb-connector",
+    "config": {
+      "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+      "topics": "metrics",
+      "connection.url": "jdbc:postgresql://localhost:5432/doc?user=crate",
+      "tasks.max": 1,
+      "insert.mode": "insert",
+      "table.name.format": "metrics",
+      "transforms.flatten.type": "org.apache.kafka.connect.transforms.Flatten$Value",
+      "transforms": "flatten",
+      "transforms.flatten.delimiter": "_"
+    }
+  }
+
+The remaining steps from above remain are applicable without changes.
 
 .. _Kafka: https://www.confluent.io/what-is-apache-kafka/
-.. _Kafka Connect JDBC connector: https://docs.confluent.io/current/connect/kafka-connect-jdbc/index.html
+.. _Kafka Connect JDBC connector: https://docs.confluent.io/kafka-connect-jdbc/current/sink-connector/
 .. _Confluent Platform: https://docs.confluent.io/current/cli/index.html
 .. _Avro schema: https://avro.apache.org/docs/current/spec.html
 .. _PostgreSQL Kafka Connect JDBC driver: https://docs.confluent.io/kafka-connect-jdbc/current/index.html#postgresql-database
 .. _Sink Connector: https://docs.confluent.io/current/connect/kafka-connect-jdbc/sink-connector/index.html
 .. _Source Connector: https://docs.confluent.io/current/connect/kafka-connect-jdbc/source-connector/index.html
 .. _Kafka Connect Transformation: https://docs.confluent.io/current/connect/transforms/index.html
-.. _Flatten Transformation: https://docs.confluent.io/current/connect/transforms/flatten.html
-.. _general Connector settings: https://docs.confluent.io/2.0.0/connect/userguide.html#configuring-connectors
-.. _JDBC Connector settings: https://docs.confluent.io/current/connect/kafka-connect-jdbc/sink-connector/sink_config_options.html
+.. _JDBC Sink Connector settings: https://docs.confluent.io/current/connect/kafka-connect-jdbc/sink-connector/sink_config_options.html
 .. _Kafka Connect: https://docs.confluent.io/current/connect/index.html


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Update of the Kafka Connect Guide with the new JSON data type (crate/crate#11592). Instead of having to flatten the payload, it can now get stored as an `OBJECT` by casting it to `JSON` during ingestion.

Unrelatedly, replaced a broken Azure Function link to satisfy the link checker.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
