### PR TITLE
remove deb-src from debian tutorial

### DIFF
--- a/docs/deployment/linux/debian.rst
+++ b/docs/deployment/linux/debian.rst
@@ -71,7 +71,6 @@ Then, edit it, and add the following:
 .. code-block:: text
 
    deb https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
-   deb-src https://cdn.crate.io/downloads/apt/CHANNEL/ CODENAME main
 
 Here, replace ``CHANNEL`` as above, and then, additionally, replace
 ``CODENAME`` with the codename of your distribution (e.g., ``buster``,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
remove `deb-src` from debian install how-to, as we don't publish source files to apt

also see https://community.crate.io/t/error-warning-when-trying-to-apt-get-cratedb-w-skipping-acquire-of-configured-file-main-source-sources/830/3

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
