### PR TITLE
Two Python fixes in time-series howtos

### DIFF
--- a/docs/getting-started/generate-time-series/python.rst
+++ b/docs/getting-started/generate-time-series/python.rst
@@ -108,7 +108,7 @@ Then, :ref:`crate-python:connect`:
 
 Get a :ref:`cursor <crate-python:cursor>`:
 
-    >>>  cursor = connection.cursor()
+    >>> cursor = connection.cursor()
 
 Finally, :ref:`create a table <crate-reference:ddl-create-table>` suitable for writing
 ISS position coordinates.

--- a/docs/getting-started/normalize-intervals.rst
+++ b/docs/getting-started/normalize-intervals.rst
@@ -694,7 +694,7 @@ that performs a left :ref:`crate-reference:inner-joins`, as per the previous
               DATE_TRUNC('minute', CURRENT_TIMESTAMP),
               '1 minute'::INTERVAL
             ) AS series(time)
-            LEFT JOIN doc.iss ON DATE_TRUNC('1 minute'::INTERVAL, iss.timestamp, 0) = time
+            LEFT JOIN doc.iss ON DATE_TRUNC('minute', iss.timestamp) = time
             GROUP BY time
             ORDER BY time ASC
         '''


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
While going through the time-series howto, I noticed two errors when running code from the howtos:

* Additional space causes an `IndentationError`
* A `DATE_TRUNC` call had wrong parameters, looks like a mix-up with `DATE_BIN`

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
