### PR TITLE
Fix broken links and update CI and RTD environments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,16 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            docs/requirements.txt
 
       - name: Build docs
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,12 +13,16 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            docs/requirements.txt
 
       - name: Build docs
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/getting-started/generate-time-series/node.rst
+++ b/docs/getting-started/generate-time-series/node.rst
@@ -340,9 +340,9 @@ will open up a map view showing the current position of the ISS:
 
 .. _await: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await
 .. _axios: https://www.npmjs.com/package/axios
-.. _Client: https://node-postgres.com/api/client
+.. _Client: https://node-postgres.com/apis/client
 .. _connect: https://node-postgres.com/features/connecting
-.. _Connection Pool: https://node-postgres.com/api/pool
+.. _Connection Pool: https://node-postgres.com/apis/pool
 .. _detailed guide: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
 .. _ground point: https://en.wikipedia.org/wiki/Ground_track
 .. _input values: https://node-postgres.com/features/queries#Parameterized%20query


### PR DESCRIPTION
Some maintenance updates.

- Fix broken links
- CI: Refresh environment setup
  - Bump GHA action recipe versions
  - Update to Python 3.10
  - Enable caching for packages downloaded from PyPI
- RTD: Update to Python 3.10
