### PR TITLE
Always use `/reference/en/latest` when linking to documentation

### DIFF
--- a/docs/best-practices/crate-node.rst
+++ b/docs/best-practices/crate-node.rst
@@ -310,7 +310,7 @@ When the node is started again, it will be able to join a new cluster.
 .. _discovery configuration: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _node.data: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-types
 .. _node.master: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-types
-.. _quorum: https://crate.io/docs/crate/reference/en/master/concepts/clustering.html#master-node-election
+.. _quorum: https://crate.io/docs/crate/reference/en/latest/concepts/clustering.html#master-node-election
 .. _repurpose command: https://crate.io/docs/crate/reference/en/latest/admin/cli-tools.html#repurpose
 .. _role: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-types
 .. _snapshot: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html

--- a/docs/clustering/multi-node-setup.rst
+++ b/docs/clustering/multi-node-setup.rst
@@ -243,13 +243,12 @@ The currently supported sources are:
    CrateDB will perform an `Amazon EC2 API`_ query and use the results to
    generate a list of `unicast hosts`_ for node discovery.
 
-3. `Microsoft Azure`_
+3. Microsoft Azure
 
    .. WARNING::
 
-     Microsoft Azure discovery was deprecated in CrateDB
-     :ref:`5.0.0 <crate-reference:version_5.0.0>` and removed in
-     :ref:`5.1.0 <crate-reference:version_5.1.0>`.
+     Microsoft Azure discovery was deprecated in CrateDB 5.0.0
+     and removed in :ref:`5.1.0 <crate-reference:version_5.1.0>`.
 
    To enable Microsoft Azure discovery, configure the ``discovery.seed_providers``
    setting in your `configuration`_ file:
@@ -494,7 +493,6 @@ Edit the `transport.tcp.port`_ setting in your `configuration`_ file:
 .. _latest: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _Metadata configuration settings: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata
 .. _metadata gateway: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#metadata-gateway
-.. _Microsoft Azure: https://crate.io/docs/crate/reference/en/5.0/config/cluster.html#discovery-on-microsoft-azure
 .. _More information about port settings: https://crate.io/docs/crate/reference/en/latest/config/node.html#ports
 .. _network.publish_host: https://crate.io/docs/crate/reference/en/latest/config/node.html#network-publish-host
 .. _node.master: https://crate.io/docs/crate/reference/en/latest/config/node.html#node-master

--- a/docs/going-into-production.rst
+++ b/docs/going-into-production.rst
@@ -443,7 +443,7 @@ network traffic between nodes and clients. Check out the reference manual on
 .. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#crate-heap-size
 .. _CRATE_HOME: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-crate-home
 .. _CRATE_JAVA_OPTS: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-java-opts
-.. _data paths: https://crate.io/docs/crate/reference/en/4.4/config/node.html#paths
+.. _data paths: https://crate.io/docs/crate/reference/en/latest/config/node.html#paths
 .. _discovery: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html#discovery
 .. _elect a master node: https://crate.io/docs/crate/reference/en/latest/concepts/shared-nothing.html#master-node-election
 .. _Filesystem Hierarchy Standard: https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard

--- a/docs/performance/inserts/bulk.rst
+++ b/docs/performance/inserts/bulk.rst
@@ -408,8 +408,8 @@ For exmaple::
 .. _ALTER TABLE ONLY: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html#alter-table-only
 .. _alter the number of shards: https://crate.io/docs/crate/reference/en/latest/general/ddl/partitioned-tables.html#changing-the-number-of-shards
 .. _availability: https://en.wikipedia.org/wiki/High_availability
-.. _bulk_size: https://crate.io/docs/crate/reference/en/master/sql/statements/copy-from.html#bulk-size
-.. _cast: https://crate.io/docs/crate/reference/en/4.4/general/ddl/data-types.html#cast
+.. _bulk_size: https://crate.io/docs/crate/reference/en/latest/sql/statements/copy-from.html#bulk-size
+.. _cast: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#cast
 .. _CLUSTERED clause: https://crate.io/docs/crate/reference/en/latest/sql/statements/create-table.html#clustered
 .. _COPY FROM: https://crate.io/docs/crate/reference/en/latest/sql/reference/copy_from.html
 .. _CrateDB Reference\: Alter a partitioned table: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html#alter
@@ -417,15 +417,15 @@ For exmaple::
 .. _CrateDB Reference\: PARTITIONED BY: https://crate.io/docs/crate/reference/en/latest/sql/statements/create-table.html#partitioned-by
 .. _CrateDB Reference\: Partitioned tables: https://crate.io/docs/crate/reference/en/latest/sql/partitioned_tables.html
 .. _distributed database: https://crate.io/docs/crate/reference/en/latest/concepts/clustering.html
-.. _drop: https://crate.io/docs/crate/reference/en/4.4/sql/statements/drop-table.html
+.. _drop: https://crate.io/docs/crate/reference/en/latest/sql/statements/drop-table.html
 .. _gzip: https://www.gnu.org/software/gzip/
 .. _IOPS: https://en.wikipedia.org/wiki/IOPS
 .. _JSON lines: https://jsonlines.org/
-.. _native support for JSON data: https://crate.io/docs/crate/reference/en/master/general/ddl/data-types.html#json
-.. _partitions: https://crate.io/docs/crate/reference/en/master/general/ddl/partitioned-tables.html
-.. _primary key: https://crate.io/docs/crate/reference/en/master/general/ddl/constraints.html#primary-key
+.. _native support for JSON data: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#json
+.. _partitions: https://crate.io/docs/crate/reference/en/latest/general/ddl/partitioned-tables.html
+.. _primary key: https://crate.io/docs/crate/reference/en/latest/general/ddl/constraints.html#primary-key
 .. _refresh_interval: https://crate.io/docs/crate/reference/en/latest/sql/reference/create_table.html#refresh-interval
 .. _refresh: https://crate.io/docs/crate/reference/en/latest/sql/refresh.html
-.. _replicas: https://crate.io/docs/crate/reference/en/master/general/ddl/replication.html
-.. _shards: https://crate.io/docs/crate/reference/en/master/general/ddl/sharding.html
+.. _replicas: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
+.. _shards: https://crate.io/docs/crate/reference/en/latest/general/ddl/sharding.html
 .. _Windows documentation: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
I noticed that there were a few occasions linking to `/reference/en/master` or `/reference/en/4.4` for no specific reason. This updated those occasions to always use `/reference/en/latest`.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
